### PR TITLE
#14 Applied patch for email_registration module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -332,6 +332,9 @@
       },
       "drupal/block_node": {
         "Add route context to block": "patches/block_node_cache_contexts.patch"
+      },
+      "drupal/email_registration": {
+        "Username is changing when admin edits profile": "https://www.drupal.org/files/issues/2019-04-02/email_registration-strange_username_logic_after_rc6_release-3024558-62.patch"
       }
     },
     "installer-paths": {


### PR DESCRIPTION
მომხმარებლის დასეივების მერე, **email_registration** ეს მოდული ცვლიდა მომხმარებლის სახელს. უბრალოდ გამოვიყენე პაჩი რომელიც ამ მოდულის issue-ებიდან ავიღე.

ამ ბრენჩის დაპულვის შემდეგ უნდა გაეშვას **docker-compose exec php composer install**