### PR TITLE
#49 - UI სტილების და სკტიპტების მენეჯმენტი

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ config/excluded/*
 
 # Certs
 /certs/
+
+front

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ default: up
 DRUPAL_ROOT ?= /var/www/html/web
 
 up:
+	@mkdir -p front
 	@echo "Starting up containers for $(PROJECT_NAME)..."
 	docker-compose pull
 	docker-compose up -d --remove-orphans
@@ -34,8 +35,10 @@ logs:
 	@docker-compose logs -f $(filter-out $@,$(MAKECMDGOALS))
 
 build-ui:
-	@rm -rf ./front/{*,.[^.]*}
-	@docker exec -ti -e COLUMNS=$(shell tput cols) -e LINES=$(shell tput lines) $(shell docker ps --filter name='$(PROJECT_NAME)_ui_builder' --format "{{ .ID }}") sh -c 'git clone $(UI_REPO) . && yarn && yarn build'
+	@mkdir -p front
+	@cd front && sudo rm -rf `ls -Ab` && cd ..
+	@git clone $(UI_REPO) front
+	@docker exec -ti -e COLUMNS=$(shell tput cols) -e LINES=$(shell tput lines) $(shell docker ps --filter name='$(PROJECT_NAME)_ui_builder' --format "{{ .ID }}") sh -c 'yarn && yarn build'
 	sudo chown $(USER):$(USER) ./front -R
 	@echo -e "\n\nGirchi UI successfully built in ./front folder!"
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@
 მიმდინარე ვერსიის ინსტალაციის ინსტრუქცია დეველოპერებისთვის: 
 
 1. `git clone git@github.com:Girchi/girchi-com-d8.git`;
-2. `cd girchi-com-d8`;
-3. `docker-compose up -d`;
-4. `./scripts/pre-install.sh`
-5. `docker-compose exec php composer install`;
-6. `docker-compose exec php drush si --existing-config --account-pass=1234 -y -vvv`
-7. `docker-compose exec php drush language-import`
+1. `cd girchi-com-d8`;
+1. `make install` ეს ნაბიჯი მოიცავს შემდეგ ქვე-ნაბიჯებს:
+
+    - `make up` - Docker კონტეინერების შექმნა და გაშვება;
+    - `make build-ui` - [Girchi UI](https://github.com/Girchi/girchi-com-ui) პროექტის „გაბილდვა“;
+    - `./scripts/pre-install.sh` - წინა საინსტალაციო პროცედურები;
+    - `docker-compose exec php composer install` - Composer პაკეტების დაყენება კონტეინერის შიგნით;
+    - `docker-compose exec php drush si --existing-config --account-pass=1234  -y -vvv` - Drupal 8 - ის ინსტალაცია არსებული კონფიგ-ფაილებიდან;
+    - `docker-compose exec php drush language-import` - თარგმანის იმპორტი;
 
 ინსტალაციის შემდეგ პროექტის უნდა მუშაობდეს შემდეგ მისამართზე: [http://girchi.docker.localhost](http://girchi.docker.localhost)
 

--- a/composer.json
+++ b/composer.json
@@ -309,10 +309,12 @@
       "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
     ],
     "post-install-cmd": [
-      "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+      "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+      "./scripts/post-install.sh"
     ],
     "post-update-cmd": [
-      "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+      "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+      "./scripts/post-install.sh"
     ],
     "project-install": "./scripts/project-install.sh",
     "project-install:prod": "./scripts/project-install.sh prod"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,25 +11,26 @@ GREEN='\033[01;32m'
 BLUE='\033[1;36m'
 
 clear
-echo -e "${BLUE}Starting up containers\n\v${NONE}"
-docker-compose pull
-docker-compose up -d --remove-orphans
-echo -e "\n"    
-echo  -e "${BLUE}Running pre-install script\n\v${NONE}"
+echo -e "${BLUE}[1/7] Starting up containers...\n\v${NONE}"
+make up
+
+echo -e "\n${BLUE}[2/7] Building UI Project...\n\v${NONE}"
+mkdir -p front
+make build-ui
+
+echo -e "\n${BLUE}[3/7] Running pre-install script...\n\v${NONE}"
 ./scripts/pre-install.sh
-echo -e "\n"
-echo  -e "${BLUE}Running composer json\n\v${NONE}"
+
+echo -e "\n${BLUE}[4/7] Running composer install...\n\v${NONE}"
 docker-compose exec php composer install
-echo -e "\n"
-echo  -e "${BLUE}Installing drupal\n\v${NONE}"
+
+echo -e "\n${BLUE}[5/7] Installing drupal...\n\v${NONE}"
 docker-compose exec php drush si --existing-config --account-pass=1234  -y -vvv 
-echo -e "\n"
-echo  -e "${BLUE}Importing translations\n\v${NONE}"
+
+echo -e "\n${BLUE}[6/7] Importing translations...\n\v${NONE}"
 docker-compose exec php drush language-import
-echo -e "\n"
-echo  -e "${BLUE}Importing config\n\v${NONE}"
+
+echo -e "\n${BLUE}[7/7] Importing config...\n\v${NONE}"
 docker-compose exec php drush cim -y -vvv
-echo -e "\n"
-clear
-echo  -e "${BLUE}D8 Project is ready${NONE} ${RED}\n\vWebsite${NONE}  - " $GREEN$WEBSITE$NONE"${RED}\n\vMailHog${NONE} - " $GREEN$MAILHOG$NONE"${RED}\n\vphpMyAdmin${NONE} - " $GREEN$PMA$NONE"\n"
-sleep 3
+
+echo -e "\n${BLUE}HGirchi Website is ready${NONE} ${GREEN}\n\vWebsite${NONE}  - " ${GREEN}${WEBSITE}${NONE}"${GREEN}\n\vMailHog${NONE} - " ${GREEN}${MAILHOG}${NONE}"${GREEN}\n\vphpMyAdmin${NONE} - " ${GREEN}${PMA}${NONE}"\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,26 +11,23 @@ GREEN='\033[01;32m'
 BLUE='\033[1;36m'
 
 clear
-echo -e "${BLUE}[1/7] Starting up containers...\n\v${NONE}"
+echo -e "${BLUE}[1/6] Starting up containers...\n\v${NONE}"
 make up
 
-echo -e "\n${BLUE}[2/7] Building UI Project...\n\v${NONE}"
+echo -e "\n${BLUE}[2/6] Building UI Project...\n\v${NONE}"
 mkdir -p front
 make build-ui
 
-echo -e "\n${BLUE}[3/7] Running pre-install script...\n\v${NONE}"
+echo -e "\n${BLUE}[3/6] Running pre-install script...\n\v${NONE}"
 ./scripts/pre-install.sh
 
-echo -e "\n${BLUE}[4/7] Running composer install...\n\v${NONE}"
+echo -e "\n${BLUE}[4/6] Running composer install...\n\v${NONE}"
 docker-compose exec php composer install
 
-echo -e "\n${BLUE}[5/7] Installing drupal...\n\v${NONE}"
+echo -e "\n${BLUE}[5/6] Installing drupal...\n\v${NONE}"
 docker-compose exec php drush si --existing-config --account-pass=1234  -y -vvv 
 
-echo -e "\n${BLUE}[6/7] Importing translations...\n\v${NONE}"
+echo -e "\n${BLUE}[6/6] Importing translations...\n\v${NONE}"
 docker-compose exec php drush language-import
-
-echo -e "\n${BLUE}[7/7] Importing config...\n\v${NONE}"
-docker-compose exec php drush cim -y -vvv
 
 echo -e "\n${BLUE}HGirchi Website is ready${NONE} ${GREEN}\n\vWebsite${NONE}  - " ${GREEN}${WEBSITE}${NONE}"${GREEN}\n\vMailHog${NONE} - " ${GREEN}${MAILHOG}${NONE}"${GREEN}\n\vphpMyAdmin${NONE} - " ${GREEN}${PMA}${NONE}"\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,23 +11,29 @@ GREEN='\033[01;32m'
 BLUE='\033[1;36m'
 
 clear
-echo -e "${BLUE}[1/6] Starting up containers...\n\v${NONE}"
+echo -e "${BLUE}[1/8] Stopping containers...\n\v${NONE}"
+make stop
+
+echo -e "${BLUE}[2/8] Starting up containers...\n\v${NONE}"
 make up
 
-echo -e "\n${BLUE}[2/6] Building UI Project...\n\v${NONE}"
+echo -e "\n${BLUE}[3/8] Building UI Project...\n\v${NONE}"
 mkdir -p front
 make build-ui
 
-echo -e "\n${BLUE}[3/6] Running pre-install script...\n\v${NONE}"
+echo -e "\n${BLUE}[4/8] Running pre-install script...\n\v${NONE}"
 ./scripts/pre-install.sh
 
-echo -e "\n${BLUE}[4/6] Running composer install...\n\v${NONE}"
+echo -e "\n${BLUE}[5/8] Running composer install...\n\v${NONE}"
 docker-compose exec php composer install
 
-echo -e "\n${BLUE}[5/6] Installing drupal...\n\v${NONE}"
+echo -e "\n${BLUE}[6/8] Installing drupal...\n\v${NONE}"
 docker-compose exec php drush si --existing-config --account-pass=1234  -y -vvv 
 
-echo -e "\n${BLUE}[6/6] Importing translations...\n\v${NONE}"
-docker-compose exec php drush language-import
+echo -e "\n${BLUE}[7/8] Importing translations...\n\v${NONE}"
+docker-compose exec php drush language-import -y
+
+echo -e "\n${BLUE}[8/8] Importing config...\n\v${NONE}"
+docker-compose exec php drush cim -y -vvv
 
 echo -e "\n${BLUE}Girchi Website is ready${NONE} ${GREEN}\n\vWebsite${NONE}  - " ${GREEN}${WEBSITE}${NONE}"${GREEN}\n\vMailHog${NONE} - " ${GREEN}${MAILHOG}${NONE}"${GREEN}\n\vphpMyAdmin${NONE} - " ${GREEN}${PMA}${NONE}"\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,7 +18,6 @@ echo -e "${BLUE}[2/8] Starting up containers...\n\v${NONE}"
 make up
 
 echo -e "\n${BLUE}[3/8] Building UI Project...\n\v${NONE}"
-mkdir -p front
 make build-ui
 
 echo -e "\n${BLUE}[4/8] Running pre-install script...\n\v${NONE}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,4 +30,4 @@ docker-compose exec php drush si --existing-config --account-pass=1234  -y -vvv
 echo -e "\n${BLUE}[6/6] Importing translations...\n\v${NONE}"
 docker-compose exec php drush language-import
 
-echo -e "\n${BLUE}HGirchi Website is ready${NONE} ${GREEN}\n\vWebsite${NONE}  - " ${GREEN}${WEBSITE}${NONE}"${GREEN}\n\vMailHog${NONE} - " ${GREEN}${MAILHOG}${NONE}"${GREEN}\n\vphpMyAdmin${NONE} - " ${GREEN}${PMA}${NONE}"\n"
+echo -e "\n${BLUE}Girchi Website is ready${NONE} ${GREEN}\n\vWebsite${NONE}  - " ${GREEN}${WEBSITE}${NONE}"${GREEN}\n\vMailHog${NONE} - " ${GREEN}${MAILHOG}${NONE}"${GREEN}\n\vphpMyAdmin${NONE} - " ${GREEN}${PMA}${NONE}"\n"

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -36,4 +36,5 @@ if [[ -d "$DEP_THEME_PATH" ]]; then
     cp ${DEP_FONTS_PATH}/* ${DEST_FONTS_PATH}/
 else
     echo -e "\e[0;5;41m ERROR: Dist folder don't found! Please, run make build-ui and then composer install\e[00m"
+    exit 1
 fi

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -35,6 +35,6 @@ if [[ -d "$DEP_THEME_PATH" ]]; then
     cp ${DEP_IMG_PATH}/* ${DEST_IMG_PATH}/
     cp ${DEP_FONTS_PATH}/* ${DEST_FONTS_PATH}/
 else
-    echo -e "\e[0;5;41m ERROR: Dist folder don't found! Please, run make build-ui and then composer install\e[00m"
+    echo -e "\e[0;5;41m ERROR: Dist folder not found! Please, run make build-ui and then composer install.\e[00m"
     exit 1
 fi

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Define variables
+
+# Script path
+BASE_DIR=$(dirname "$0")
+
+# Departure paths
+DEP_THEME_PATH="$BASE_DIR/../front/dist"
+DEP_CSS_PATH=${DEP_THEME_PATH}
+DEP_JS_PATH=${DEP_THEME_PATH}
+DEP_IMG_PATH="$DEP_THEME_PATH/images"
+DEP_FONTS_PATH="$DEP_THEME_PATH/fonts"
+
+# Destination paths
+DEST_THEME_PATH="$BASE_DIR/../web/themes/custom/girchi"
+DEST_CSS_PATH="$DEST_THEME_PATH/css"
+DEST_JS_PATH="$DEST_THEME_PATH/js"
+DEST_IMG_PATH="$DEST_THEME_PATH/images"
+DEST_FONTS_PATH="$DEST_CSS_PATH/fonts"
+
+# Check if DEP_THEME_PATH exists
+if [[ -d "$DEP_THEME_PATH" ]]; then
+    # Create destination directories if they don't exists
+    mkdir -p ${DEST_CSS_PATH}
+    mkdir -p ${DEST_JS_PATH}
+    mkdir -p ${DEST_IMG_PATH}
+    mkdir -p ${DEST_FONTS_PATH}
+
+    # Copy files
+    cp ${DEP_CSS_PATH}/bundle-*.css ${DEST_CSS_PATH}/custom.css
+    #cp ${DEP_CSS_PATH}/bundle-*.js.map ${DEST_CSS_PATH}/custom.css.map
+    cp ${DEP_JS_PATH}/bundle-*.js ${DEST_JS_PATH}/script.js
+    #cp ${DEP_JS_PATH}/bundle-*.js.map ${DEST_JS_PATH}/script.js.map
+    cp ${DEP_IMG_PATH}/* ${DEST_IMG_PATH}/
+    cp ${DEP_FONTS_PATH}/* ${DEST_FONTS_PATH}/
+else
+    echo -e "\e[0;5;41m ERROR: Dist folder don't found! Please, run make build-ui and then composer install"
+fi

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -35,5 +35,5 @@ if [[ -d "$DEP_THEME_PATH" ]]; then
     cp ${DEP_IMG_PATH}/* ${DEST_IMG_PATH}/
     cp ${DEP_FONTS_PATH}/* ${DEST_FONTS_PATH}/
 else
-    echo -e "\e[0;5;41m ERROR: Dist folder don't found! Please, run make build-ui and then composer install"
+    echo -e "\e[0;5;41m ERROR: Dist folder don't found! Please, run make build-ui and then composer install\e[00m"
 fi


### PR DESCRIPTION
Issue: #49 

# განახლებები
- დავამატე ახალი პოსტ-ინსტალ სკრიპტი, რომელიც #56 -ის ფარგლებში შექმნილი `dist` საქაღალდიდან დააკოპირებს საჭირო სკრიპტებს, სტილებს, სურათებს და ა.შ თემის სათანადო საქაღალდეებში.

**სკრიპტი ეშვება ყოველი `composer install` ან `composer update` -ის გაშვების შემდეგ.**

- შევცვალე `install.sh` სკრიპტი (რომელიც ეშვება `make install` ბრძანების გაშვების შედეგად), კერძოდ დავამატე ახალი ნაბიჯი (`make build-ui`) რომელიც ბილდავს UI პროექტს, რათა შეიქმნას `dist` საქაღალდე, საიდანაც სკრიპტი აიღებს საჭირო ფაილებს.

# ინსტალაცია
ამიერიდან პროექტის დასაინსტალირებლად და გასამართად საკმარისია მხოლოდ `make install` ბრძანების გაშვება (დეტალურად იხილეთ [README](https://github.com/Girchi/girchi-com-d8/blob/49-ui-management-automatization/README.md) ფაილში).