### PR TITLE
#134 Patch video embed facebook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -346,6 +346,9 @@
 	    "Access user emails " : "https://www.drupal.org/files/issues/2019-04-26/drupal-2799049-30-new-permission-view-user-mail.patch",
         "Fix Entity reference autocomplete with fields": "https://www.drupal.org/files/issues/2019-04-16/2174633-views-273.patch",
         "Fix ajax error in views relationships" : "https://www.drupal.org/files/issues/2019-05-04/2457999-194.patch"
+      },
+      "drupal/video_embed_facebook": {
+        "iframe fix": "https://www.drupal.org/files/issues/2019-05-13/facebook_embed_field.patch"
       }
     },
     "installer-paths": {


### PR DESCRIPTION
#134 
## განხილვა
 Play - ღილაკი არ ჩანდა მხოლოდ facebook  ვიდეობისთვის.
 გავასწორეთ პაჩის გამოყენებით 

## ინსტალაცია
*  `docker compose exec php composer install`