### PR TITLE
221 news category

### DIFF
--- a/web/modules/custom/girchi_utils/src/Plugin/Block/CategoryFilterBlock.php
+++ b/web/modules/custom/girchi_utils/src/Plugin/Block/CategoryFilterBlock.php
@@ -28,10 +28,17 @@ class  CategoryFilterBlock extends BlockBase
     {
         $categories_tree =  Drupal::service('girchi_utils.taxonomy_term_tree')->load('news_categories');
         $current_category = \Drupal::request()->query->get('category');
+        $path = \Drupal::service('path.alias_manager')->getPathByAlias('/media/news/14-ad-huic-melior-ymo');
+
+        if(preg_match('/node\/(\d+)/', $path, $matches)) {
+          $node = \Drupal\node\Entity\Node::load($matches[1]);
+          $current_category = $node->get('field_category')[0]->entity->id();
+        }
+
         return array(
                 '#theme' => 'categories_block',
                 '#categories' => $categories_tree,
-                '#current_category' => $current_category
+                '#current_category' => $current_category,
             );
 
     }

--- a/web/themes/custom/girchi/js/global.js
+++ b/web/themes/custom/girchi/js/global.js
@@ -1,41 +1,5 @@
 $(document).ready(function () {
-    $('#edit-field-politician-value').on('change', (e) => {
-        if (e.target.checked) {
-            $('.form-checkbox-input').addClass('checked');
-        } else {
-            $('.form-checkbox-input').removeClass('checked');
-        }
-    })
-
-    // Video blog carousel
-    const videoCarousel = $('.front-news-carousel').owlCarousel({
-        margin: 10,
-        dotsContainer: $('.front-news-carousel-dots'),
-        responsive: {
-            0: {
-                items: 2,
-                slideBy: 2
-            },
-            480: {
-                items: 2,
-                slideBy: 2
-            },
-            768: {
-                items: 2,
-                slideBy: 2
-            },
-            992: {
-                items: 5,
-                slideBy: 5
-            }
-        }
-    })
-    $('.front-news-carousel-next').on('click', () => {
-        videoCarousel.trigger('next.owl.carousel')
-    })
-    $('.front-news-carousel-prev').on('click', () => {
-        videoCarousel.trigger('prev.owl.carousel')
-    })
+    
     $('#edit-field-politician-value').on('change', (e) => {
          if (e.target.checked) {
             $('.form-checkbox-input').addClass('checked');

--- a/web/themes/custom/girchi/js/global.js
+++ b/web/themes/custom/girchi/js/global.js
@@ -1,4 +1,12 @@
 $(document).ready(function () {
+    $('#edit-field-politician-value').on('change', (e) => {
+        if (e.target.checked) {
+            $('.form-checkbox-input').addClass('checked');
+        } else {
+            $('.form-checkbox-input').removeClass('checked');
+        }
+    })
+
     // Video blog carousel
     const videoCarousel = $('.front-news-carousel').owlCarousel({
         margin: 10,


### PR DESCRIPTION
#221 

## კონტექსტი
გასწორდა ჯავასკრიპტი კატეგორიების მენიუსთივს
კონკრეტული სიახლის გახსნის შემთხვევაში, ამ სიახლის ერთი მშობელი კატეგორია ან შესაბამისი  მშობლის ქვეშ არსებული ქვეკატეგორია ჩაშლება. ( კატეგორიები არის checkbox-ები, ამიტომ ცოტა რთულია გავნსაზღვროთ პრიორიტეტი რომელი კატეგორია ჩაიშალოს, ამიტომ პირველი კატეგორია რომელიც შეხვდება იმას ჩაშლის.)

