### PR TITLE
305 sitemap generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -254,6 +254,7 @@
     "drupal/role_delegation": "^1.0@alpha",
     "drupal/search_api": "^1.0",
     "drupal/select_or_other": "^1.0@alpha",
+    "drupal/simple_sitemap": "^3.2",
     "drupal/smart_trim": "^1.0",
     "drupal/social_auth_facebook": "^1.0",
     "drupal/static_server": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2703b06cfa010a993d78b5d1b14efad5",
+    "content-hash": "988673c9e9d71878c1eaadacc3a4b260",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -7920,6 +7920,67 @@
             "homepage": "https://www.drupal.org/project/select_or_other",
             "support": {
                 "source": "http://cgit.drupalcode.org/select_or_other"
+            }
+        },
+        {
+            "name": "drupal/simple_sitemap",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/simple_sitemap.git",
+                "reference": "8.x-3.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-8.x-3.2.zip",
+                "reference": "8.x-3.2",
+                "shasum": "2f499e7133a2031f6372c2f3d12fbbb3a64120df"
+            },
+            "require": {
+                "drupal/core": "~8.0",
+                "ext-xmlwriter": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.2",
+                    "datestamp": "1559004185",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Pawel Ginalski (gbyte.co)",
+                    "homepage": "https://www.drupal.org/u/gbyte.co",
+                    "email": "contact@gbyte.co",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "gbyte.co",
+                    "homepage": "https://www.drupal.org/user/2381352"
+                }
+            ],
+            "description": "Creates a standard conform hreflang XML sitemap of the site content and provides a framework for developing other sitemap types.",
+            "homepage": "https://drupal.org/project/simple_sitemap",
+            "support": {
+                "source": "https://cgit.drupalcode.org/simple_sitemap",
+                "issues": "https://drupal.org/project/issues/simple_sitemap",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -81,6 +81,7 @@ module:
   search_api_db: 0
   serialization: 0
   shortcut: 0
+  simple_sitemap: 0
   social_api: 0
   social_auth: 0
   social_auth_facebook: 0

--- a/config/sync/simple_sitemap.bundle_settings.default.node.article.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.node.article.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.node.page.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.node.page.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.news_categories.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.news_categories.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.tags.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.tags.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/sync/simple_sitemap.custom_links.default.yml
+++ b/config/sync/simple_sitemap.custom_links.default.yml
@@ -1,0 +1,7 @@
+links:
+  -
+    path: /
+    priority: '1.0'
+    changefreq: daily
+_core:
+  default_config_hash: 25hWeYa4sasuJtHqKKcEN_nYiuEC1lMPYHsn5dawJEw

--- a/config/sync/simple_sitemap.settings.yml
+++ b/config/sync/simple_sitemap.settings.yml
@@ -1,0 +1,17 @@
+max_links: 2000
+cron_generate: true
+cron_generate_interval: 0
+generate_duration: 10000
+remove_duplicates: true
+skip_untranslated: true
+xsl: true
+base_url: ''
+default_variant: default
+custom_links_include_images: false
+excluded_languages: {  }
+enabled_entity_types:
+  - node
+  - taxonomy_term
+  - menu_link_content
+_core:
+  default_config_hash: LWI5gcV7qtIl5h1xg7AWMtepAzBAvTaw_TOmsQbw9Tk

--- a/config/sync/simple_sitemap.variants.default_hreflang.yml
+++ b/config/sync/simple_sitemap.variants.default_hreflang.yml
@@ -1,0 +1,6 @@
+variants:
+  default:
+    label: Default
+    weight: 0
+_core:
+  default_config_hash: nQAXscP-SDpsmqHlQ6u0iBvcuJPrAikb09c3cP2_n0k

--- a/web/modules/custom/girchi_utils/girchi_utils.module
+++ b/web/modules/custom/girchi_utils/girchi_utils.module
@@ -10,6 +10,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
 use Drupal\user\Entity\User;
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * Implements hook_token_info().
@@ -405,4 +406,41 @@ function girchi_utils_cron()
    */
   $rankRaiting = Drupal::service('girchi_utils.ged_raiting');
   $rankRaiting->calculateRankRating();
+
+}
+
+/**
+ * Implements hook_simple_sitemap_links_alter().
+ */
+function girchi_utils_simple_sitemap_links_alter(array &$links, $sitemap_variant)
+{
+  $term_url_mapping = [
+    'news_categories' => 'news?category=',
+    'tags' => 'news?tag=',
+  ];
+
+  foreach ($links as $key => $link) {
+    if (
+      isset($link['meta']['entity_info']['entity_type'])
+      && $link['meta']['entity_info']['entity_type'] === 'taxonomy_term'
+    ) {
+      $tid = $link['meta']['entity_info']['id'];
+
+      // Get taxonomy term bundle.
+      $term = Term::load($tid);
+      $term_bundle = $term->bundle();
+
+      $old_path = $link['meta']['path'];
+      $new_path = $term_url_mapping[$term_bundle] . $tid;
+
+      $links[$key]['meta']['path'] = $new_path;
+      $links[$key]['url'] = str_replace($old_path, $new_path, $links[$key]['url']);
+
+      foreach ($link['alternate_urls'] as $k => $alt_url) {
+        $links[$key]['alternate_urls'][$k] = str_replace($old_path, $new_path, $alt_url);
+      }
+
+    }
+  }
+
 }


### PR DESCRIPTION
# აღწერა
გაკეთდა `sitemap`-ის გენერაცია საიტზე.

# ინსტრუქცია 
გაუშვით ბრძანება `docker-compose exec php composer install` , `make drush cim`, `make drush cr`.

# გასატესტად
დააგენერირეთ არტიკლის ტიპის კონტენტი, დაამატეთ კატეგორიები და თეგები. გაუშვით `cron`-ი და შედით შემდეგ მისამართზე `http://girchi.docker.localhost/sitemap.xml`.