### PR TITLE
Fix girchi_ged_transactions module's public name.

### DIFF
--- a/web/modules/custom/girchi_ged_transactions/girchi_ged_transactions.info.yml
+++ b/web/modules/custom/girchi_ged_transactions/girchi_ged_transactions.info.yml
@@ -1,4 +1,4 @@
-name: 'girchi_ged_transactions'
+name: 'Girchi GED Transactions'
 type: module
 description: 'Module for ged transactions'
 core: 8.x


### PR DESCRIPTION
არაკონსისტენტურია ყველა სხვა მოდულს რომ ნორმალურად ჰქვია საჯარო სახელი და ამას ერქვა - girchi_get_transactions.