### PR TITLE
Fix donation transactions type with drush command.

### DIFF
--- a/web/modules/custom/girchi_ged_transactions/src/Commands/GirchiGedTransactionsCommands.php
+++ b/web/modules/custom/girchi_ged_transactions/src/Commands/GirchiGedTransactionsCommands.php
@@ -73,4 +73,26 @@ class GirchiGedTransactionsCommands extends DrushCommands {
     }
   }
 
+  /**
+   * Main command.
+   *
+   * @command girchi_ged_transactions:fix-donation-transactions
+   * @aliases fix-donation-transactions
+   */
+  public function setTypeForDonationTransactions() {
+    $ged_transactions_storage = $this->entityTypeManager->getStorage('ged_transaction');
+    $ged_transactions_ids = $ged_transactions_storage->getQuery()
+      ->condition('Description', 'Transaction was created by donation', '=')
+      ->execute();
+
+    $ged_transactions = $ged_transactions_storage->loadMultiple($ged_transactions_ids);
+
+    $transaction_type_id = $this->entityTypeManager->getStorage('taxonomy_term')->load(1369);
+
+    foreach ($ged_transactions as $ged_transaction) {
+      $ged_transaction->set("transaction_type", $transaction_type_id);
+      $ged_transaction->save();
+    }
+  }
+
 }


### PR DESCRIPTION
##  :bell: ვმერჯავთ #444-ის დამერჯვის შემდეგ
#544 
### აღწერა
დაემატა სკრიპტი, რომელიც დონაციების შედეგად გაკეთებულ ტრანზაქციებს დაუსეტავს ტრანზაქციის ტიპს.

### ინსტალაცია
გატესტეთ ფროდაქშენის ბაზაზე.
გაუშვით შემდეგი ბრძანება:
`make drush cr` , 
`make drush fix-donation-transactions`.

Ged transactions ვიუში ბოლოს დამატებულ დონაციების ტრანზაქციას ტრანზაქციის ტიპში უნდა ეწეროს `0026 - ფულადი კონტრიბუცია`.