### PR TITLE
632 donation fixups

### DIFF
--- a/web/modules/custom/girchi_donations/src/Commands/GirchiDonationsCommands.php
+++ b/web/modules/custom/girchi_donations/src/Commands/GirchiDonationsCommands.php
@@ -168,7 +168,7 @@ class GirchiDonationsCommands extends DrushCommands {
    */
   public function getMothDays() {
     $response = [];
-    $period = CarbonPeriod::create(Carbon::createFromDate(2020, 1, 16), Carbon::today());
+    $period = CarbonPeriod::create(Carbon::createFromDate(2020, 1, 16), Carbon::yesterday());
 
     /** @var \Carbon\Carbon $day */
     foreach ($period as $day) {

--- a/web/modules/custom/girchi_donations/src/Commands/GirchiDonationsCommands.php
+++ b/web/modules/custom/girchi_donations/src/Commands/GirchiDonationsCommands.php
@@ -153,6 +153,7 @@ class GirchiDonationsCommands extends DrushCommands {
         $regd->save();
         $progressBar->advance();
       }
+      $output->writeln("\n");
       $progressBar->finish();
 
     }
@@ -167,7 +168,7 @@ class GirchiDonationsCommands extends DrushCommands {
    */
   public function getMothDays() {
     $response = [];
-    $period = CarbonPeriod::create(Carbon::createFromDate(2019, 12, 25), Carbon::today());
+    $period = CarbonPeriod::create(Carbon::createFromDate(2020, 1, 16), Carbon::today());
 
     /** @var \Carbon\Carbon $day */
     foreach ($period as $day) {

--- a/web/modules/custom/girchi_donations/src/Controller/DonationsController.php
+++ b/web/modules/custom/girchi_donations/src/Controller/DonationsController.php
@@ -264,7 +264,7 @@ class DonationsController extends ControllerBase {
             $ged_amount = $this->gedCalculator->calculate($gel_amount);
             if ($user->id() !== '0') {
               $transaction = $ged_manager->create([
-                'user_id' => "1",
+                'user_id' => '1',
                 'user' => $user->id(),
                 'ged_amount' => $ged_amount,
                 'title' => 'Donation',
@@ -275,12 +275,12 @@ class DonationsController extends ControllerBase {
               ]);
               $transaction->save();
               $donation->set('field_ged_transaction', $transaction->id());
-              $donation->save();
               $auth = TRUE;
             }
             else {
               $auth = FALSE;
             }
+            $donation->save();
             $donationEvent = new DonationEvents($donation);
             $this->dispatcher->dispatch(DonationEventsConstants::DONATION_SUCCESS, $donationEvent);
             $this->getLogger('girchi_donations')


### PR DESCRIPTION
## აღწერა 📄
ანონიმური მომხარებლის სტატუსი წარმატების შემთხვევაში განახლდება რამაც აღარ უნდა მოგვცეს სხვაობა საიტის დონაციებსა და ბანკის ამონაწერს შორის. ასევე განახლდა დრაშის ქომანდი რომელიჩ რეგულარული დონაციის დღეებს ასწორებს 

## ინსტალაცია :gear: 

- `make` drush cim
- `make` drush cr

## გატესტვა 🧪

#### ლოკალურად 🏡

- შეამოწმეთ ქომანდი: **drush restore-dates** (შესაბამის ბაზაზე)

#### სტეიჯინგი :small_airplane: 
- შექმენით ერთჯერადი დონაცია როგორც ავტირიზორებული ისე ანონიმური მომხარებლით და შეამოწმეთ სტატუსი
- დაამატეთ ბარათი
- მიაბით ბარათს რეგულარული დონაცია
- შეამოწმეთ თანხის ჩამოჭრა 