### PR TITLE
636 jwt integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -295,6 +295,7 @@
     "drush/drush": "~9.5",
     "enyo/dropzone": "4.2.0",
     "eyecon/colorpicker": "^1.0",
+    "firebase/php-jwt": "^5.1",
     "google/apiclient": "^2.0",
     "harvesthq/chosen": "1.8.7",
     "nesbot/carbon": "^2.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c1cb162f0b02f0d0bcadcb992fb0ef4",
+    "content-hash": "4a5e3fd4c8e177fc0ba73fc8a743efb4",
     "packages": [
         {
             "name": "abgeo/nbg-currency",
@@ -10788,23 +10788,23 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v5.0.0",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "9984a4d3a32ae7673d6971ea00bae9d0a1abba0e"
+                "reference": "4566062c68f76f43d44f1643f4970fe89757d4c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/9984a4d3a32ae7673d6971ea00bae9d0a1abba0e",
-                "reference": "9984a4d3a32ae7673d6971ea00bae9d0a1abba0e",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/4566062c68f76f43d44f1643f4970fe89757d4c6",
+                "reference": "4566062c68f76f43d44f1643f4970fe89757d4c6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": " 4.8.35"
+                "phpunit/phpunit": "^4.8|^5"
             },
             "type": "library",
             "autoload": {
@@ -10830,7 +10830,7 @@
             ],
             "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
             "homepage": "https://github.com/firebase/php-jwt",
-            "time": "2017-06-27T22:17:23+00:00"
+            "time": "2020-02-24T23:15:03+00:00"
         },
         {
             "name": "giggsey/libphonenumber-for-php",

--- a/config/sync/core.entity_form_display.user.user.default.yml
+++ b/config/sync/core.entity_form_display.user.user.default.yml
@@ -27,6 +27,7 @@ dependencies:
     - field.field.user.user.field_referral_benefits
     - field.field.user.user.field_referral_date
     - field.field.user.user.field_referral_url
+    - field.field.user.user.field_refresh_token
     - field.field.user.user.field_social_auth_password
     - field.field.user.user.field_tel
     - field.field.user.user.field_twitter_url
@@ -248,6 +249,7 @@ hidden:
   field_rank: true
   field_referral_benefits: true
   field_referral_date: true
+  field_refresh_token: true
   field_social_auth_password: true
   google_analytics: true
   langcode: true

--- a/config/sync/core.entity_view_display.user.user.default.yml
+++ b/config/sync/core.entity_view_display.user.user.default.yml
@@ -27,6 +27,7 @@ dependencies:
     - field.field.user.user.field_referral_benefits
     - field.field.user.user.field_referral_date
     - field.field.user.user.field_referral_url
+    - field.field.user.user.field_refresh_token
     - field.field.user.user.field_social_auth_password
     - field.field.user.user.field_tel
     - field.field.user.user.field_twitter_url
@@ -217,6 +218,7 @@ hidden:
   field_profile_video: true
   field_public_email: true
   field_referral_date: true
+  field_refresh_token: true
   field_social_auth_password: true
   field_twitter_url: true
   langcode: true

--- a/config/sync/field.field.user.user.field_refresh_token.yml
+++ b/config/sync/field.field.user.user.field_refresh_token.yml
@@ -1,0 +1,20 @@
+uuid: fcc2818f-520a-43ea-bb3f-97184aa68a58
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_refresh_token
+  module:
+    - user
+id: user.user.field_refresh_token
+field_name: field_refresh_token
+entity_type: user
+bundle: user
+label: Refresh_token
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.user.field_refresh_token.yml
+++ b/config/sync/field.storage.user.field_refresh_token.yml
@@ -1,0 +1,21 @@
+uuid: d40371e3-2717-4e93-8a1f-83385c56f9e6
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_refresh_token
+field_name: field_refresh_token
+entity_type: user
+type: string
+settings:
+  max_length: 1000
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/girchi_users/Credentials/.cred.env.dist
+++ b/web/modules/custom/girchi_users/Credentials/.cred.env.dist
@@ -1,0 +1,3 @@
+PRIVATE_KEY="enter private key"
+
+PUBLIC_KEY="enter public key"

--- a/web/modules/custom/girchi_users/Credentials/.gitignore
+++ b/web/modules/custom/girchi_users/Credentials/.gitignore
@@ -1,0 +1,4 @@
+*
+*/
+!.cred.env.dist
+!.gitignore

--- a/web/modules/custom/girchi_users/girchi_users.module
+++ b/web/modules/custom/girchi_users/girchi_users.module
@@ -8,6 +8,8 @@
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+use Drupal\girchi_users\Event\UserLoginEvent;
+use Drupal\user\UserInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -149,5 +151,14 @@ function girchi_users_pass_reset_custom_submit(array $form, FormStateInterface $
   $url .= '?pass-reset=success';
   $response = new RedirectResponse($url);
   $response->send();
+}
+
+/**
+ * Implements hook_user_login().
+ */
+function girchi_users_user_login(UserInterface $account) {
+  $event = new UserLoginEvent($account);
+  $event_dispatcher = \Drupal::service('event_dispatcher');
+  $event_dispatcher->dispatch(UserLoginEvent::USER_LOGIN, $event);
 
 }

--- a/web/modules/custom/girchi_users/girchi_users.routing.yml
+++ b/web/modules/custom/girchi_users/girchi_users.routing.yml
@@ -32,3 +32,12 @@ girchi_users.user_controller_removeFavoriteNews:
   requirements:
     _permission: 'access content'
     _role: 'authenticated'
+
+girchi_users.user_controller_jwtRefreshToken:
+  path: '/api/jwt/refreshToken'
+  defaults:
+    _controller: '\Drupal\girchi_users\Controller\UserController::jwtRefreshToken'
+    _title: 'Generate jwt refresh token'
+  requirements:
+    _permission: 'access content'
+    _role: 'authenticated'

--- a/web/modules/custom/girchi_users/girchi_users.routing.yml
+++ b/web/modules/custom/girchi_users/girchi_users.routing.yml
@@ -34,7 +34,7 @@ girchi_users.user_controller_removeFavoriteNews:
     _role: 'authenticated'
 
 girchi_users.user_controller_jwtRefreshToken:
-  path: '/api/jwt/refreshToken'
+  path: '/api/jwt/token_refresh'
   defaults:
     _controller: '\Drupal\girchi_users\Controller\UserController::jwtRefreshToken'
     _title: 'Generate jwt refresh token'

--- a/web/modules/custom/girchi_users/girchi_users.services.yml
+++ b/web/modules/custom/girchi_users/girchi_users.services.yml
@@ -2,7 +2,15 @@ services:
   girchi_users.event_subscriber:
     class: Drupal\girchi_users\EventSubscriber\SocialAuthSubscriber
     tags:
-      - { name: 'event_subscriber' }  
+      - { name: 'event_subscriber' }
+  girchi_users.on_login:
+    class: Drupal\girchi_users\EventSubscriber\AuthenticationSubscriber
+    tags:
+      - { name: 'event_subscriber' }
+    arguments: ['@logger.factory', '@request_stack', '@current_user', '@girchi_users.generate_jwt']
   girchi_users.ged_helper:
     class: Drupal\girchi_users\GEDHelperService
     arguments: []
+  girchi_users.generate_jwt:
+    class: Drupal\girchi_users\GenerateJWT
+    arguments: ['@logger.factory', '@request_stack', '@current_user', '@entity_type.manager']

--- a/web/modules/custom/girchi_users/girchi_users.services.yml
+++ b/web/modules/custom/girchi_users/girchi_users.services.yml
@@ -12,5 +12,5 @@ services:
     class: Drupal\girchi_users\GEDHelperService
     arguments: []
   girchi_users.generate_jwt:
-    class: Drupal\girchi_users\GenerateJWT
+    class: Drupal\girchi_users\GenerateJwtService
     arguments: ['@logger.factory', '@request_stack', '@current_user', '@entity_type.manager']

--- a/web/modules/custom/girchi_users/src/Controller/UserController.php
+++ b/web/modules/custom/girchi_users/src/Controller/UserController.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Zend\Diactoros\Response\JsonResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * Class UserController.
@@ -167,7 +167,7 @@ class UserController extends ControllerBase {
    *
    *   Request.
    *
-   * @return \Zend\Diactoros\Response\JsonResponse
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
    *
    *   JsonResponse
    */
@@ -212,7 +212,7 @@ class UserController extends ControllerBase {
    * @param int $nid
    *   Node id.
    *
-   * @return \Zend\Diactoros\Response\JsonResponse
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
    *   Json.
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
@@ -240,7 +240,7 @@ class UserController extends ControllerBase {
    * @param int $nid
    *   Node id.
    *
-   * @return \Zend\Diactoros\Response\JsonResponse
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
    *   Json.
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
@@ -265,7 +265,7 @@ class UserController extends ControllerBase {
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   Request.
    *
-   * @return \Zend\Diactoros\Response\JsonResponse
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
    *   Json.
    */
   public function jwtRefreshToken(Request $request) {
@@ -275,7 +275,7 @@ class UserController extends ControllerBase {
     if ($current_refresh_token == $user_refresh_token) {
       $this->generateJWT->generateJwt();
     }
-    return new JsonResponse("success");
+    return new JsonResponse('success');
 
   }
 

--- a/web/modules/custom/girchi_users/src/Controller/UserController.php
+++ b/web/modules/custom/girchi_users/src/Controller/UserController.php
@@ -8,7 +8,7 @@ use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\girchi_users\GenerateJWT;
+use Drupal\girchi_users\GenerateJwtService;
 use Drupal\social_auth\SocialAuthDataHandler;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -61,7 +61,7 @@ class UserController extends ControllerBase {
   /**
    * Generate jwt.
    *
-   * @var \Drupal\girchi_users\GenerateJWT
+   * @var \Drupal\girchi_users\GenerateJwtService
    */
   protected $generateJWT;
 
@@ -76,14 +76,14 @@ class UserController extends ControllerBase {
    *   LoggerFactory.
    * @param \Drupal\Core\Config\ConfigFactory $configFactory
    *   ConfigFactory.
-   * @param \Drupal\girchi_users\GenerateJWT $generateJWT
-   *   GenerateJWT.
+   * @param \Drupal\girchi_users\GenerateJwtService $generateJWT
+   *   GenerateJwtService.
    */
   public function __construct(EntityTypeManagerInterface $entity_type_manager,
-  SocialAuthDataHandler $socialAuthDataHandler,
-                                LoggerChannelFactoryInterface $loggerFactory,
-  ConfigFactory $configFactory,
-                                GenerateJWT $generateJWT) {
+                              SocialAuthDataHandler $socialAuthDataHandler,
+                              LoggerChannelFactoryInterface $loggerFactory,
+                              ConfigFactory $configFactory,
+                              GenerateJwtService $generateJWT) {
 
     $this->entityTypeManager = $entity_type_manager;
     $this->SocialAuthDataHandler = $socialAuthDataHandler;

--- a/web/modules/custom/girchi_users/src/Event/UserLoginEvent.php
+++ b/web/modules/custom/girchi_users/src/Event/UserLoginEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\girchi_users\Event;
+
+use Drupal\user\UserInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event that is fired when a user logs in.
+ */
+class UserLoginEvent extends Event {
+
+  const USER_LOGIN = 'girchi_users.user.login';
+
+  /**
+   * The user account.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  public $account;
+
+  /**
+   * Constructs the object.
+   *
+   * @param \Drupal\user\UserInterface $account
+   *   The account of the user logged in.
+   */
+  public function __construct(UserInterface $account) {
+    $this->account = $account;
+  }
+
+}

--- a/web/modules/custom/girchi_users/src/EventSubscriber/AuthenticationSubscriber.php
+++ b/web/modules/custom/girchi_users/src/EventSubscriber/AuthenticationSubscriber.php
@@ -93,18 +93,19 @@ class AuthenticationSubscriber implements EventSubscriberInterface {
    *   Event.
    */
   public function onResponse(FilterResponseEvent $event) {
+    $host = $this->request->getCurrentRequest()->getHost();
     if (!empty($this->request->getCurrentRequest()->getSession()->get('g-u-at'))) {
       $jwt = $this->request->getCurrentRequest()->getSession()->get('g-u-at');
       $refresh_token = $this->request->getCurrentRequest()->getSession()->get('g-u-rt');
-      $jwt_cookie = new Cookie('g-u-at', $jwt, time() + 18000);
-      $refresh_token_cookie = new Cookie('g-u-rt', $refresh_token, time() + 18000);
+      $jwt_cookie = new Cookie('g-u-at', $jwt, time() + 18000, '', $host, FALSE, FALSE);
+      $refresh_token_cookie = new Cookie('g-u-rt', $refresh_token, time() + 18000, '', $host, FALSE, FALSE);
       $event->getResponse()->headers->setCookie($jwt_cookie);
       $event->getResponse()->headers->setCookie($refresh_token_cookie);
     }
 
     if ($this->accountProxy->isAnonymous() && !empty($this->request->getCurrentRequest()->getSession()->get('g-u-at'))) {
-      $event->getResponse()->headers->clearCookie('g-u-at');
-      $event->getResponse()->headers->clearCookie('g-u-rt');
+      $event->getResponse()->headers->clearCookie('g-u-at', '', $host);
+      $event->getResponse()->headers->clearCookie('g-u-rt', '', $host);
     }
 
   }

--- a/web/modules/custom/girchi_users/src/EventSubscriber/AuthenticationSubscriber.php
+++ b/web/modules/custom/girchi_users/src/EventSubscriber/AuthenticationSubscriber.php
@@ -5,7 +5,7 @@ namespace Drupal\girchi_users\EventSubscriber;
 use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\Core\Session\AccountProxy;
 use Drupal\girchi_users\Event\UserLoginEvent;
-use Drupal\girchi_users\GenerateJWT;
+use Drupal\girchi_users\GenerateJwtService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -40,7 +40,7 @@ class AuthenticationSubscriber implements EventSubscriberInterface {
   /**
    * Generate jwt.
    *
-   * @var \Drupal\girchi_users\GenerateJWT
+   * @var \Drupal\girchi_users\GenerateJwtService
    */
   protected $generateJWT;
 
@@ -53,10 +53,10 @@ class AuthenticationSubscriber implements EventSubscriberInterface {
    *   Request.
    * @param \Drupal\Core\Session\AccountProxy $accountProxy
    *   Account proxy.
-   * @param \Drupal\girchi_users\GenerateJWT $generateJWT
+   * @param \Drupal\girchi_users\GenerateJwtService $generateJWT
    *   Generate jwt token.
    */
-  public function __construct(LoggerChannelFactory $loggerFactory, RequestStack $requestStack, AccountProxy $accountProxy, GenerateJWT $generateJWT) {
+  public function __construct(LoggerChannelFactory $loggerFactory, RequestStack $requestStack, AccountProxy $accountProxy, GenerateJwtService $generateJWT) {
     $this->generateJWT = $generateJWT;
     $this->loggerFactory = $loggerFactory->get('girchi_users');
     $this->request = $requestStack;

--- a/web/modules/custom/girchi_users/src/EventSubscriber/AuthenticationSubscriber.php
+++ b/web/modules/custom/girchi_users/src/EventSubscriber/AuthenticationSubscriber.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\girchi_users\EventSubscriber;
+
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\girchi_users\Event\UserLoginEvent;
+use Drupal\girchi_users\GenerateJWT;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Authentication Subsciriber.
+ */
+class AuthenticationSubscriber implements EventSubscriberInterface {
+  /**
+   * Logger Factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   */
+  protected $loggerFactory;
+
+  /**
+   * Request.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $request;
+
+  /**
+   * Account proxy.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $accountProxy;
+
+  /**
+   * Generate jwt.
+   *
+   * @var \Drupal\girchi_users\GenerateJWT
+   */
+  protected $generateJWT;
+
+  /**
+   * Constructs a new AuthenticationSubscriber object.
+   *
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerFactory
+   *   Logger messages.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+   *   Request.
+   * @param \Drupal\Core\Session\AccountProxy $accountProxy
+   *   Account proxy.
+   * @param \Drupal\girchi_users\GenerateJWT $generateJWT
+   *   Generate jwt token.
+   */
+  public function __construct(LoggerChannelFactory $loggerFactory, RequestStack $requestStack, AccountProxy $accountProxy, GenerateJWT $generateJWT) {
+    $this->generateJWT = $generateJWT;
+    $this->loggerFactory = $loggerFactory->get('girchi_users');
+    $this->request = $requestStack;
+    $this->accountProxy = $accountProxy;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      UserLoginEvent::USER_LOGIN => 'onUserLogin',
+      KernelEvents::RESPONSE => 'onResponse',
+    ];
+
+  }
+
+  /**
+   * On user login.
+   */
+  public function onUserLogin(UserLoginEvent $event) {
+    try {
+      $this->generateJWT->generateJwt();
+    }
+    catch (\Exception $e) {
+      $this->loggerFactory->error($e);
+    }
+  }
+
+  /**
+   * On KernelEvent response.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   *   Event.
+   */
+  public function onResponse(FilterResponseEvent $event) {
+    if (!empty($this->request->getCurrentRequest()->getSession()->get('g-u-at'))) {
+      $jwt = $this->request->getCurrentRequest()->getSession()->get('g-u-at');
+      $refresh_token = $this->request->getCurrentRequest()->getSession()->get('g-u-rt');
+      $jwt_cookie = new Cookie('g-u-at', $jwt, time() + 18000);
+      $refresh_token_cookie = new Cookie('g-u-rt', $refresh_token, time() + 18000);
+      $event->getResponse()->headers->setCookie($jwt_cookie);
+      $event->getResponse()->headers->setCookie($refresh_token_cookie);
+    }
+
+    if ($this->accountProxy->isAnonymous() && !empty($this->request->getCurrentRequest()->getSession()->get('g-u-at'))) {
+      $event->getResponse()->headers->clearCookie('g-u-at');
+      $event->getResponse()->headers->clearCookie('g-u-rt');
+    }
+
+  }
+
+}

--- a/web/modules/custom/girchi_users/src/GenerateJWT.php
+++ b/web/modules/custom/girchi_users/src/GenerateJWT.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\girchi_users;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\Session\AccountProxy;
+use Firebase\JWT\JWT;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class GenerateJWT.
+ */
+class GenerateJWT {
+  /**
+   * Logger Factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   */
+  protected $loggerFactory;
+
+  /**
+   * Request.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $request;
+
+  /**
+   * Account proxy.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $accountProxy;
+
+  /**
+   * EntityTypeManagerInterface.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new AuthenticationSubscriber object.
+   *
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerFactory
+   *   Logger messages.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+   *   Request.
+   * @param \Drupal\Core\Session\AccountProxy $accountProxy
+   *   Account proxy.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   Entity Type Manager.
+   */
+  public function __construct(LoggerChannelFactory $loggerFactory, RequestStack $requestStack, AccountProxy $accountProxy, EntityTypeManagerInterface $entityTypeManager) {
+    $this->loggerFactory = $loggerFactory->get('girchi_users');
+    $this->request = $requestStack;
+    $this->accountProxy = $accountProxy;
+    $this->entityTypeManager = $entityTypeManager;
+
+  }
+
+  /**
+   * Generate jwt token.
+   */
+  public function generateJwt() {
+    try {
+      $dotEnv = new Dotenv();
+      $dotEnv->load('modules/custom/girchi_users' . '/Credentials/.cred.env');
+      $privateKey = $_ENV['PRIVATE_KEY'];
+
+      // Id of logged in user.
+      $uid = $this->accountProxy->id();
+      $current_user = $this->entityTypeManager->getStorage('user')->load($uid);
+      // Generate random hash for refresh token.
+      $refresh_token = bin2hex(random_bytes(20)) . uniqid();
+      // Set refresh token to user field field_refresh_token.
+      $current_user->set('field_refresh_token', $refresh_token);
+      $current_user->save();
+
+      // Create payload.
+      $payload = [
+        'user_id' => $uid,
+        'exp' => strtotime('+30 minutes'),
+      ];
+
+      // Generate JWT token.
+      $jwt = JWT::encode($payload, $privateKey, 'RS256');
+      // Set jwt in session.
+      $session = $this->request->getCurrentRequest()->getSession();
+      // Girchi user access token.
+      $session->set('g-u-at', $jwt);
+      // Girchi user refresh token.
+      $session->set('g-u-rt', $refresh_token);
+
+    }
+    catch (\Exception $e) {
+      $this->loggerFactory->error($e);
+
+    }
+  }
+
+}

--- a/web/modules/custom/girchi_users/src/GenerateJwtService.php
+++ b/web/modules/custom/girchi_users/src/GenerateJwtService.php
@@ -10,9 +10,9 @@ use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Class GenerateJWT.
+ * Class GenerateJwtService.
  */
-class GenerateJWT {
+class GenerateJwtService {
   /**
    * Logger Factory.
    *


### PR DESCRIPTION
#636 
## აღწერა
მომხმარებლის დალოგინებისას იქმნება jwt ტოკენი და refresh ტოკენი. რეფრეშ ტოკენი იწერება მომხმარებლის ახლად დამატებულ ველში `field_refresh_token` და jwt-ტოკენის ვადის გასვლის შემდეგ რეფრეშ ტოკენით ხდება მომხმარებლის იდენტობის დადგენა და ხელახალი jwt token-ის დაგენერირება.

## ინსტალაცია
`composer install`
`drush cim`
`drush cr`

## გატესტვა: 
პირველ რიგში გატესტვის მიზნით დააკომენტარეთ if statement-ი (მარტო if, ლოგიკა უნდა იყოს)`web/modules/custom/girchi_users/src/Controller/UserController.php` **275 line**.
`web/modules/custom/girchi_users/Credentials` აქ შექმენით `.cred.env` ფაილი და დაამატეთ ქრედენშალები.

- დალოგინდით მომხმარებლით და შეამოწმენთ, რომ ქუქიში ნამდვილად დაესეტა jwt და refresh ტოკენი
- გადადით სხვადასხვა გვერდზე და დარწმუნდით, რომ არცერთი ტოკენი არ იცვლება.
- `/api/jwt/refreshToken` ამ ენდფოინთზე შესვლისას უნდა მოხდეს ორივე ტოკენის განახლება. და ამავდროულად (მომავალში) ეს უნდა იყოს ენდფოინთი, რომელზეც კლიენტი refresh token-ს გამოაგზავნის მომხმარებლის იდენტობის შესამოწმებლად.
- გამოლოგაუთდით და შეამოწმეთ, რომ ქუქიდან ორივე ტოკენი წაშლილია


