### PR TITLE
691 notifications service

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.donation_issues.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.donation_issues.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.donation_issues.field_image
+    - field.field.taxonomy_term.donation_issues.field_user
     - image.style.thumbnail
     - taxonomy.vocabulary.donation_issues
   module:
@@ -30,6 +31,15 @@ content:
       preview_image_style: thumbnail
     third_party_settings: {  }
     type: image_image
+    region: content
+  field_user:
+    weight: 32
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   langcode:
     type: language_select

--- a/config/sync/core.entity_view_display.taxonomy_term.donation_issues.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.donation_issues.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.donation_issues.field_image
+    - field.field.taxonomy_term.donation_issues.field_user
     - taxonomy.vocabulary.donation_issues
   module:
     - image
@@ -28,6 +29,14 @@ content:
       image_link: ''
     third_party_settings: {  }
     type: image
+    region: content
+  field_user:
+    weight: 2
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
 hidden:
   langcode: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -49,6 +49,7 @@ module:
   girchi_ged_transactions: 0
   girchi_leaderboard: 0
   girchi_my_party_list: 0
+  girchi_notifications: 0
   girchi_paypal: 0
   girchi_referral: 0
   girchi_users: 0

--- a/config/sync/field.field.taxonomy_term.donation_issues.field_user.yml
+++ b/config/sync/field.field.taxonomy_term.donation_issues.field_user.yml
@@ -1,0 +1,28 @@
+uuid: 103f13ff-c0a6-4bcf-beca-5a8d12ca1405
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_user
+    - taxonomy.vocabulary.donation_issues
+id: taxonomy_term.donation_issues.field_user
+field_name: field_user
+entity_type: taxonomy_term
+bundle: donation_issues
+label: User
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:user'
+  handler_settings:
+    include_anonymous: false
+    filter:
+      type: _none
+    target_bundles: null
+    sort:
+      field: _none
+    auto_create: false
+field_type: entity_reference

--- a/config/sync/field.storage.taxonomy_term.field_user.yml
+++ b/config/sync/field.storage.taxonomy_term.field_user.yml
@@ -1,0 +1,20 @@
+uuid: cb35d4ac-8fc0-4547-98f7-aba09640e004
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+    - user
+id: taxonomy_term.field_user
+field_name: field_user
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: user
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/girchi_leaderboard/src/Form/LeaderboardForm.php
+++ b/web/modules/custom/girchi_leaderboard/src/Form/LeaderboardForm.php
@@ -9,7 +9,6 @@ use Drupal\girchi_donations\Event\DonationEvents;
 use Drupal\girchi_donations\Event\DonationEventsConstants;
 use Drupal\girchi_donations\Utils\CreateGedTransaction;
 use Drupal\girchi_donations\Utils\DonationUtils;
-use Drupal\girchi_notifications\GetUserInfoService;
 use Drupal\girchi_notifications\NotifyDonationService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -69,14 +68,6 @@ class LeaderboardForm extends FormBase {
   protected $dispatcher;
 
   /**
-   * GetUserInfoService.
-   *
-   * @var \Drupal\girchi_notifications\GetUserInfoService
-   */
-  protected $getUserInfoService;
-
-
-  /**
    * NotifyDonationService.
    *
    * @var \Drupal\girchi_notifications\NotifyDonationService
@@ -94,8 +85,6 @@ class LeaderboardForm extends FormBase {
    *   CreateGedTransaction.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
    *   Dispatcher.
-   * @param \Drupal\girchi_notifications\GetUserInfoService $getUserInfoService
-   *   Get user info.
    * @param \Drupal\girchi_notifications\NotifyDonationService $notifyDonationService
    *   NotifyDonationService.
    */
@@ -103,7 +92,6 @@ class LeaderboardForm extends FormBase {
                               MessengerInterface $messenger,
                               CreateGedTransaction $createGedTransaction,
                               EventDispatcherInterface $dispatcher,
-                              GetUserInfoService $getUserInfoService,
                               NotifyDonationService $notifyDonationService) {
 
     $this->donationUtils = $donationUtils;
@@ -113,7 +101,6 @@ class LeaderboardForm extends FormBase {
     $this->currency = $donationUtils->gedCalculator->getCurrency();
     $this->createGedTransaction = $createGedTransaction;
     $this->dispatcher = $dispatcher;
-    $this->getUserInfoService = $getUserInfoService;
     $this->notifyDonationService = $notifyDonationService;
 
   }
@@ -127,7 +114,6 @@ class LeaderboardForm extends FormBase {
       $container->get('messenger'),
       $container->get('girchi_donations.create_ged_transaction'),
       $container->get('event_dispatcher'),
-      $container->get('girchi_notifications.get_user_info'),
       $container->get('girchi_notifications.get_assigned_aim_user')
     );
   }
@@ -237,9 +223,7 @@ class LeaderboardForm extends FormBase {
           $this->getLogger('girchi_leaderboard')->info('Saved to donations with Status: OK');
           $event = new DonationEvents($valid);
           $this->dispatcher->dispatch(DonationEventsConstants::DONATION_SUCCESS, $event);
-          // $invoker is person who caused notification.
-          $invoker = $this->getUserInfoService->getUserInfo($user);
-          $this->notifyDonationService->notifyDonation($type, $invoker, $amount, $user, $donation_aim);
+          $this->notifyDonationService->notifyDonation($valid);
         }
       }
       else {

--- a/web/modules/custom/girchi_my_party_list/girchi_my_party_list.info.yml
+++ b/web/modules/custom/girchi_my_party_list/girchi_my_party_list.info.yml
@@ -3,3 +3,5 @@ type: module
 description: 'Module for my party list form'
 core: 8.x
 package: 'girchi'
+dependencies:
+  - girchi_notifications:girchi_notifications

--- a/web/modules/custom/girchi_my_party_list/girchi_my_party_list.module
+++ b/web/modules/custom/girchi_my_party_list/girchi_my_party_list.module
@@ -8,7 +8,6 @@
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\girchi_notifications\Constants\NotificationConstants;
 
 /**
  * Implements hook_help().
@@ -101,89 +100,9 @@ function girchi_my_party_list_user_presave(EntityInterface $user) {
   }
 
   if (!$user->isNew()) {
-    $supporters = $user->get('field_my_party_list')->value ? $user->get('field_my_party_list') : NULL;
-    $user_id = $user->id();
-    /** @var \Drupal\girchi_notifications\GetUserInfoService $getUserInfoService */
-    $getUserInfoService = \Drupal::service('girchi_notifications.get_user_info');
-    /** @var \Drupal\girchi_notifications\NotifyUserService $notifyUserService */
-    $notifyUserService = \Drupal::service('girchi_notifications.notify_user');
-    $type = NotificationConstants::PARTY_LIST;
-    $type_en = NotificationConstants::PARTY_LIST_EN;
-    $getUserInfo = $getUserInfoService->getUserInfo($user_id);
-    if (!empty($supporters)) {
-      $supporter_id_array = [];
-      $original_supporter_id_array = [];
-      foreach ($supporters as $supporter) {
-        $supporter_id = $supporter->target_id;
-        $supporter_id_array[] = $supporter_id;
-        $ged_percentage = $supporter->value;
-        $user_ged_amount = $user->get('field_ged')->value ? $user->get('field_ged')->value : 0;
-        $supporter_ged_amount = round($user_ged_amount * $ged_percentage / 100);
-        $longFormattedGed = number_format($supporter_ged_amount, 0, ',', ' ');
-        // If party list wasn't empty:
-        if (!empty($user->original->get('field_my_party_list')->value)) {
-          $original_supporters = $user->original->get('field_my_party_list');
-          foreach ($original_supporters as $original_supporter) {
-            $original_user_id = $original_supporter->target_id;
-            $original_supporter_id_array[] = $original_user_id;
-            $original_value = $original_supporter->value;
-            // Notify supporter that user decreased amount of ged percentage.
-            if ($original_user_id == $supporter_id && $original_value > $ged_percentage) {
-              $text = "${getUserInfo['full_name']}-მ შეგიმცირათ პოლიტიკური ჯედები ${original_value}%-დან ${ged_percentage}%-მდე - ${longFormattedGed}G.";
-              $text_en = "${getUserInfo['full_name']} has decreased the amount of your political GED-s from ${original_value}% to ${ged_percentage}% - ${longFormattedGed}G.";
-              $notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
-            }
-            // Notify supporter that user increased amount of ged percentage.
-            elseif ($original_user_id == $supporter_id && $original_value < $ged_percentage) {
-              $text = "${getUserInfo['full_name']}-მ გაგიზარდათ პოლიტიკური ჯედები ${original_value}%-დან ${ged_percentage}%-მდე - ${longFormattedGed}G.";
-              $text_en = "${getUserInfo['full_name']} has increased the amount of your political GED-s from ${original_value}% to ${ged_percentage}% - ${longFormattedGed}G.";
-              $notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
-            }
-          }
-          // Notify if users party list wasn't empty
-          // and supporter was added in it.
-          if (!in_array($supporter_id, $original_supporter_id_array)) {
-            $text = "${getUserInfo['full_name']}-მ დაგამატათ პირად პარტიულ სიაში.";
-            $text_en = "${getUserInfo['full_name']} has added you to the private party list.";
-            $notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
-          }
-
-        }
-        // Notify if current state of party list was empty
-        // and supporter was added in it.
-        else {
-          $text = "${getUserInfo['full_name']}-მ დაგამატათ პირად პარტიულ სიაში.";
-          $text_en = "${getUserInfo['full_name']} has added you to the private party list.";
-          $notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
-        }
-      }
-      // Notify if current state of party list wasn't empty
-      // and supporter was removed from it.
-      if (!empty($user->original->get('field_my_party_list')->value)) {
-        foreach ($user->original->get('field_my_party_list') as $origin_supporter) {
-          $original_supporter_id = $origin_supporter->target_id;
-          if (!in_array($original_supporter_id, $supporter_id_array)) {
-            $text = "${getUserInfo['full_name']}-მ წაგშალათ პირადი პარტიული სიიდან.";
-            $text_en = "${getUserInfo['full_name']} has removed you from private party list.";
-            $notifyUserService->notifyUser($original_supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
-          }
-        }
-      }
-
-    }
-    // Notify if current state of party list was empty
-    // and supporter was removed from it.
-    elseif (empty($supporters) && !empty($user->original->get('field_my_party_list')->value)) {
-      $supporters = $user->original->get('field_my_party_list');
-      foreach ($supporters as $supporter) {
-        $supporter_id = $supporter->target_id;
-        $text = "${getUserInfo['full_name']}-მ წაგშალათ პირადი პარტიული სიიდან.";
-        $text_en = "${getUserInfo['full_name']} has removed you from private party list.";
-        $notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
-
-      }
-    }
-
+    /** @var Drupal\girchi_my_party_list\PartyListChangeDetectionService $partyListChangeDetectionService */
+    $partyListChangeDetectionService = \Drupal::service('girchi_my_party_list.party_list_change_detection_service');
+    $partyListChangeDetectionService->partyListChangeDetection($user);
   }
 
 }

--- a/web/modules/custom/girchi_my_party_list/girchi_my_party_list.module
+++ b/web/modules/custom/girchi_my_party_list/girchi_my_party_list.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\girchi_notifications\Constants\NotificationConstants;
 
 /**
  * Implements hook_help().
@@ -98,4 +99,91 @@ function girchi_my_party_list_user_presave(EntityInterface $user) {
       }
     }
   }
+
+  if (!$user->isNew()) {
+    $supporters = $user->get('field_my_party_list')->value ? $user->get('field_my_party_list') : NULL;
+    $user_id = $user->id();
+    /** @var \Drupal\girchi_notifications\GetUserInfoService $getUserInfoService */
+    $getUserInfoService = \Drupal::service('girchi_notifications.get_user_info');
+    /** @var \Drupal\girchi_notifications\NotifyUserService $notifyUserService */
+    $notifyUserService = \Drupal::service('girchi_notifications.notify_user');
+    $type = NotificationConstants::PARTY_LIST;
+    $type_en = NotificationConstants::PARTY_LIST_EN;
+    $getUserInfo = $getUserInfoService->getUserInfo($user_id);
+    if (!empty($supporters)) {
+      $supporter_id_array = [];
+      $original_supporter_id_array = [];
+      foreach ($supporters as $supporter) {
+        $supporter_id = $supporter->target_id;
+        $supporter_id_array[] = $supporter_id;
+        $ged_percentage = $supporter->value;
+        $user_ged_amount = $user->get('field_ged')->value ? $user->get('field_ged')->value : 0;
+        $supporter_ged_amount = round($user_ged_amount * $ged_percentage / 100);
+        $longFormattedGed = number_format($supporter_ged_amount, 0, ',', ' ');
+        // If party list wasn't empty:
+        if (!empty($user->original->get('field_my_party_list')->value)) {
+          $original_supporters = $user->original->get('field_my_party_list');
+          foreach ($original_supporters as $original_supporter) {
+            $original_user_id = $original_supporter->target_id;
+            $original_supporter_id_array[] = $original_user_id;
+            $original_value = $original_supporter->value;
+            // Notify supporter that user decreased amount of ged percentage.
+            if ($original_user_id == $supporter_id && $original_value > $ged_percentage) {
+              $text = "${getUserInfo['full_name']}-მ შეგიმცირათ პოლიტიკური ჯედები ${original_value}%-დან ${ged_percentage}%-მდე - ${longFormattedGed}G.";
+              $text_en = "${getUserInfo['full_name']} has decreased the amount of your political GED-s from ${original_value}% to ${ged_percentage}% - ${longFormattedGed}G.";
+              $notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
+            }
+            // Notify supporter that user increased amount of ged percentage.
+            elseif ($original_user_id == $supporter_id && $original_value < $ged_percentage) {
+              $text = "${getUserInfo['full_name']}-მ გაგიზარდათ პოლიტიკური ჯედები ${original_value}%-დან ${ged_percentage}%-მდე - ${longFormattedGed}G.";
+              $text_en = "${getUserInfo['full_name']} has increased the amount of your political GED-s from ${original_value}% to ${ged_percentage}% - ${longFormattedGed}G.";
+              $notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
+            }
+          }
+          // Notify if users party list wasn't empty
+          // and supporter was added in it.
+          if (!in_array($supporter_id, $original_supporter_id_array)) {
+            $text = "${getUserInfo['full_name']}-მ დაგამატათ პირად პარტიულ სიაში.";
+            $text_en = "${getUserInfo['full_name']} has added you to the private party list.";
+            $notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
+          }
+
+        }
+        // Notify if current state of party list was empty
+        // and supporter was added in it.
+        else {
+          $text = "${getUserInfo['full_name']}-მ დაგამატათ პირად პარტიულ სიაში.";
+          $text_en = "${getUserInfo['full_name']} has added you to the private party list.";
+          $notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
+        }
+      }
+      // Notify if current state of party list wasn't empty
+      // and supporter was removed from it.
+      if (!empty($user->original->get('field_my_party_list')->value)) {
+        foreach ($user->original->get('field_my_party_list') as $origin_supporter) {
+          $original_supporter_id = $origin_supporter->target_id;
+          if (!in_array($original_supporter_id, $supporter_id_array)) {
+            $text = "${getUserInfo['full_name']}-მ წაგშალათ პირადი პარტიული სიიდან.";
+            $text_en = "${getUserInfo['full_name']} has removed you from private party list.";
+            $notifyUserService->notifyUser($original_supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
+          }
+        }
+      }
+
+    }
+    // Notify if current state of party list was empty
+    // and supporter was removed from it.
+    elseif (empty($supporters) && !empty($user->original->get('field_my_party_list')->value)) {
+      $supporters = $user->original->get('field_my_party_list');
+      foreach ($supporters as $supporter) {
+        $supporter_id = $supporter->target_id;
+        $text = "${getUserInfo['full_name']}-მ წაგშალათ პირადი პარტიული სიიდან.";
+        $text_en = "${getUserInfo['full_name']} has removed you from private party list.";
+        $notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
+
+      }
+    }
+
+  }
+
 }

--- a/web/modules/custom/girchi_my_party_list/girchi_my_party_list.services.yml
+++ b/web/modules/custom/girchi_my_party_list/girchi_my_party_list.services.yml
@@ -4,5 +4,4 @@ services:
     arguments: ['@entity_type.manager',  '@request_stack', '@logger.factory', '@database']
   girchi_my_party_list.party_list_change_detection_service:
     class: Drupal\girchi_my_party_list\PartyListChangeDetectionService
-    arguments:
-      ['@girchi_notifications.get_user_info', '@girchi_notifications.notify_user']
+    arguments: ['@girchi_notifications.get_user_info', '@girchi_notifications.notify_user']

--- a/web/modules/custom/girchi_my_party_list/girchi_my_party_list.services.yml
+++ b/web/modules/custom/girchi_my_party_list/girchi_my_party_list.services.yml
@@ -2,3 +2,7 @@ services:
   girchi_my_party_list.party_list_calculator:
     class: Drupal\girchi_my_party_list\PartyListCalculatorService
     arguments: ['@entity_type.manager',  '@request_stack', '@logger.factory', '@database']
+  girchi_my_party_list.party_list_change_detection_service:
+    class: Drupal\girchi_my_party_list\PartyListChangeDetectionService
+    arguments:
+      ['@girchi_notifications.get_user_info', '@girchi_notifications.notify_user']

--- a/web/modules/custom/girchi_my_party_list/src/Controller/PartyListController.php
+++ b/web/modules/custom/girchi_my_party_list/src/Controller/PartyListController.php
@@ -187,7 +187,7 @@ class PartyListController extends ControllerBase {
           if (!empty($user->get('user_picture')[0])) {
             $imgId = $user->get('user_picture')[0]->getValue()['target_id'];
             $imgFile = $this->entityTypeManager->getStorage('file')->load($imgId);
-            $style = $this->entityTypeManager()->getStorage('image_style')->load('party_member');
+            $style = $this->entityTypeManager->getStorage('image_style')->load('party_member');
             $imgUrl = $style->buildUrl($imgFile->getFileUri());
           }
           else {

--- a/web/modules/custom/girchi_my_party_list/src/PartyListChangeDetectionService.php
+++ b/web/modules/custom/girchi_my_party_list/src/PartyListChangeDetectionService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Drupal\girchi_my_party_list;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\girchi_notifications\Constants\NotificationConstants;
+use Drupal\girchi_notifications\GetUserInfoService;
+use Drupal\girchi_notifications\NotifyUserService;
+
+/**
+ * PartyListChangeDetectionService.
+ */
+class PartyListChangeDetectionService {
+  /**
+   * GetUserInfoService.
+   *
+   * @var \Drupal\girchi_notifications\GetUserInfoService
+   */
+  protected $getUserInfoService;
+
+  /**
+   * NotifyUserService.
+   *
+   * @var \Drupal\girchi_notifications\NotifyUserService
+   */
+  protected $notifyUserService;
+
+  /**
+   * Constructs a new PartyListChangeDetectionService object.
+   *
+   * @param \Drupal\girchi_notifications\GetUserInfoService $getUserInfoService
+   *   GetUserInfoService.
+   * @param \Drupal\girchi_notifications\NotifyUserService $notifyUserService
+   *   NotifyUserService.
+   */
+  public function __construct(GetUserInfoService $getUserInfoService, NotifyUserService $notifyUserService) {
+    $this->getUserInfoService = $getUserInfoService;
+    $this->notifyUserService = $notifyUserService;
+  }
+
+  /**
+   * PartyListChangeDetection.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $user
+   *  User.
+   */
+  public function partyListChangeDetection(EntityInterface $user) {
+    /** @var \Drupal\Core\Field\FieldItemList $supporters */
+    $supporters = $user->get('field_my_party_list')->value ? $user->get('field_my_party_list') : NULL;
+    $user_id = $user->id();
+    $type = NotificationConstants::PARTY_LIST;
+    $type_en = NotificationConstants::PARTY_LIST_EN;
+    $getUserInfo = $this->getUserInfoService->getUserInfo($user_id);
+    $original_supporter_id_array = [];
+    if (!empty($user->original->get('field_my_party_list')->value)) {
+      $original_supporters = $user->original->get('field_my_party_list');
+      foreach ($original_supporters as $original_supporter) {
+        $original_user_id = $original_supporter->target_id;
+        $original_value = $original_supporter->value;
+        $original_supporter_id_array[$original_user_id] = $original_value;
+
+        // Notify if current state of party list is empty
+        // and supporter was removed from last submit.
+        if (empty($supporters)) {
+          $supporter_id = $original_user_id;
+          $text = "${getUserInfo['full_name']}-მ წაგშალათ პირადი პარტიული სიიდან.";
+          $text_en = "${getUserInfo['full_name']} has removed you from private party list.";
+          $this->notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
+        }
+
+        // Notify if current state of party list wasn't empty
+        // and supporter was removed from it.
+        if (!empty($supporters)) {
+          $supporters_new = clone $supporters;
+          /** @var \Drupal\Core\Field\FieldItemList $supporter_exists */
+          $supporter_exists = $supporters_new->filter(static function ($supporter) use ($original_supporter) {
+            return $original_supporter->target_id == $supporter->target_id;
+          });
+          if ($supporter_exists->isEmpty()) {
+            $text = "${getUserInfo['full_name']}-მ წაგშალათ პირადი პარტიული სიიდან.";
+            $text_en = "${getUserInfo['full_name']} has removed you from private party list.";
+            $this->notifyUserService->notifyUser($original_user_id, $getUserInfo, $type, $type_en, $text, $text_en);
+          }
+        }
+      }
+    }
+
+    if (!empty($supporters)) {
+      foreach ($supporters as $supporter) {
+        $supporter_id = $supporter->target_id;
+        $ged_percentage = $supporter->value;
+        $user_ged_amount = $user->get('field_ged')->value ? $user->get('field_ged')->value : 0;
+        $supporter_ged_amount = round($user_ged_amount * $ged_percentage / 100);
+        $longFormattedGed = number_format($supporter_ged_amount, 0, ',', ' ');
+        // If party list wasn't empty:
+        if (!empty($user->original->get('field_my_party_list')->value)) {
+          // Notify supporter that user decreased amount of ged percentage.
+          if (array_key_exists($supporter_id, $original_supporter_id_array)) {
+            $original_value = $original_supporter_id_array[$supporter_id];
+            // Notify supporter that user decreased amount of ged percentage.
+            if ($original_supporter_id_array[$supporter_id] > $ged_percentage) {
+              $text = "${getUserInfo['full_name']}-მ შეგიმცირათ პოლიტიკური ჯედები ${original_value}%-დან ${ged_percentage}%-მდე - ${longFormattedGed}G.";
+              $text_en = "${getUserInfo['full_name']} has decreased the amount of your political GED-s from ${original_value}% to ${ged_percentage}% - ${longFormattedGed}G.";
+              $this->notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
+            }
+            // Notify supporter that user increased amount of ged percentage.
+            elseif ($original_supporter_id_array[$supporter_id] < $ged_percentage) {
+              $text = "${getUserInfo['full_name']}-მ გაგიზარდათ პოლიტიკური ჯედები ${original_value}%-დან ${ged_percentage}%-მდე - ${longFormattedGed}G.";
+              $text_en = "${getUserInfo['full_name']} has increased the amount of your political GED-s from ${original_value}% to ${ged_percentage}% - ${longFormattedGed}G.";
+              $this->notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
+            }
+          }
+          // Notify if users party list wasn't empty
+          // and supporter was added in it.
+          elseif (!array_key_exists($supporter_id, $original_supporter_id_array)) {
+            $text = "${getUserInfo['full_name']}-მ დაგამატათ პირად პარტიულ სიაში.";
+            $text_en = "${getUserInfo['full_name']} has added you to the private party list.";
+            $this->notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
+          }
+        }
+        // Notify if current state of party list was empty
+        // and supporter was added in it.
+        else {
+          $text = "${getUserInfo['full_name']}-მ დაგამატათ პირად პარტიულ სიაში.";
+          $text_en = "${getUserInfo['full_name']} has added you to the private party list.";
+          $this->notifyUserService->notifyUser($supporter_id, $getUserInfo, $type, $type_en, $text, $text_en);
+        }
+      }
+    }
+
+  }
+
+}

--- a/web/modules/custom/girchi_my_party_list/src/PartyListChangeDetectionService.php
+++ b/web/modules/custom/girchi_my_party_list/src/PartyListChangeDetectionService.php
@@ -42,7 +42,7 @@ class PartyListChangeDetectionService {
    * PartyListChangeDetection.
    *
    * @param \Drupal\Core\Entity\EntityInterface $user
-   *  User.
+   *   User.
    */
   public function partyListChangeDetection(EntityInterface $user) {
     /** @var \Drupal\Core\Field\FieldItemList $supporters */

--- a/web/modules/custom/girchi_notifications/Credentials/.cred.env.dist
+++ b/web/modules/custom/girchi_notifications/Credentials/.cred.env.dist
@@ -1,0 +1,1 @@
+HOST='http://girchi_node:3000/notifications/'

--- a/web/modules/custom/girchi_notifications/Credentials/.gitignore
+++ b/web/modules/custom/girchi_notifications/Credentials/.gitignore
@@ -1,0 +1,4 @@
+*
+*/
+!.cred.env.dist
+!.gitignore

--- a/web/modules/custom/girchi_notifications/composer.json
+++ b/web/modules/custom/girchi_notifications/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "org/girchi_notifications",
+    "description": "This extension provides new commands for Drush.",
+    "type": "drupal-drush",
+    "authors": [
+        {
+            "name": "Author name",
+            "email": "author@example.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.6.0"
+    },
+    "extra": {
+        "drush": {
+            "services": {
+                "drush.services.yml": "^9"
+            }
+        }
+    }
+}

--- a/web/modules/custom/girchi_notifications/drush.services.yml
+++ b/web/modules/custom/girchi_notifications/drush.services.yml
@@ -1,0 +1,7 @@
+services:
+  girchi_notifications.commands:
+    class: Drupal\girchi_notifications\Commands\GirchiNotificationsCommands
+    tags:
+      - { name: drush.command }
+    arguments:
+      ['@entity_type.manager', '@config.factory', '@logger.factory']

--- a/web/modules/custom/girchi_notifications/girchi_notifications.info.yml
+++ b/web/modules/custom/girchi_notifications/girchi_notifications.info.yml
@@ -2,4 +2,4 @@ name: 'girchi_notifications'
 type: module
 description: 'Module for notifications'
 core: 8.x
-package: 'Custom'
+package: 'girchi'

--- a/web/modules/custom/girchi_notifications/girchi_notifications.info.yml
+++ b/web/modules/custom/girchi_notifications/girchi_notifications.info.yml
@@ -1,0 +1,5 @@
+name: 'girchi_notifications'
+type: module
+description: 'Module for notifications'
+core: 8.x
+package: 'Custom'

--- a/web/modules/custom/girchi_notifications/girchi_notifications.module
+++ b/web/modules/custom/girchi_notifications/girchi_notifications.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains girchi_notifications.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function girchi_notifications_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the girchi_notifications module.
+    case 'help.page.girchi_notifications':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Module for notifications') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/web/modules/custom/girchi_notifications/girchi_notifications.module
+++ b/web/modules/custom/girchi_notifications/girchi_notifications.module
@@ -22,3 +22,17 @@ function girchi_notifications_help($route_name, RouteMatchInterface $route_match
     default:
   }
 }
+
+/**
+ * Implements hook_theme().
+ */
+function girchi_notifications_theme($existing, $type, $theme, $path) {
+  $templates = [
+    'girchi_notifications' => [
+      'template' => 'girchi-notifications',
+      'render element' => 'children',
+    ],
+  ];
+
+  return $templates;
+}

--- a/web/modules/custom/girchi_notifications/girchi_notifications.routing.yml
+++ b/web/modules/custom/girchi_notifications/girchi_notifications.routing.yml
@@ -1,0 +1,7 @@
+girchi_notifications.notifications:
+  path: '/notifications'
+  defaults:
+    _controller: '\Drupal\girchi_notifications\Controller\NotificationController::notifications'
+    _title: 'Notifications page'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/girchi_notifications/girchi_notifications.services.yml
+++ b/web/modules/custom/girchi_notifications/girchi_notifications.services.yml
@@ -4,8 +4,8 @@ services:
     arguments: ['@entity_type.manager', '@logger.factory']
   girchi_notifications.notify_user:
     class: Drupal\girchi_notifications\NotifyUserService
-    arguments: ['@logger.factory', '@request_stack']
+    arguments: ['@logger.factory', '@request_stack', '@http_client']
   girchi_notifications.get_assigned_aim_user:
     class: Drupal\girchi_notifications\NotifyDonationService
     arguments: ['@entity_type.manager', '@logger.factory',
-                '@girchi_notifications.notify_user']
+                '@girchi_notifications.notify_user', '@girchi_notifications.get_user_info']

--- a/web/modules/custom/girchi_notifications/girchi_notifications.services.yml
+++ b/web/modules/custom/girchi_notifications/girchi_notifications.services.yml
@@ -8,4 +8,4 @@ services:
   girchi_notifications.get_assigned_aim_user:
     class: Drupal\girchi_notifications\NotifyDonationService
     arguments: ['@entity_type.manager', '@logger.factory',
-                '@girchi_notifications.notify_user', '@string_translation']
+                '@girchi_notifications.notify_user']

--- a/web/modules/custom/girchi_notifications/girchi_notifications.services.yml
+++ b/web/modules/custom/girchi_notifications/girchi_notifications.services.yml
@@ -1,0 +1,11 @@
+services:
+  girchi_notifications.get_user_info:
+    class: Drupal\girchi_notifications\GetUserInfoService
+    arguments: ['@entity_type.manager', '@logger.factory']
+  girchi_notifications.notify_user:
+    class: Drupal\girchi_notifications\NotifyUserService
+    arguments: ['@logger.factory', '@request_stack']
+  girchi_notifications.get_assigned_aim_user:
+    class: Drupal\girchi_notifications\NotifyDonationService
+    arguments: ['@entity_type.manager', '@logger.factory',
+                '@girchi_notifications.notify_user', '@string_translation']

--- a/web/modules/custom/girchi_notifications/src/Commands/GirchiNotificationsCommands.php
+++ b/web/modules/custom/girchi_notifications/src/Commands/GirchiNotificationsCommands.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\girchi_notifications\Commands;
+
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ *
+ */
+class GirchiNotificationsCommands extends DrushCommands {
+  /**
+   * EntityTypeManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * ConfigFactory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+
+  /**
+   * LoggerFactory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * Construct.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   ET manager.
+   * @param \Drupal\Core\Config\ConfigFactory $configFactory
+   *   ConfigFactory.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   *   Logger.
+   */
+  public function __construct(EntityTypeManager $entityTypeManager, ConfigFactory $configFactory, LoggerChannelFactoryInterface $loggerFactory) {
+    parent::__construct();
+    $this->entityTypeManager = $entityTypeManager;
+    $this->configFactory = $configFactory;
+    $this->loggerFactory = $loggerFactory->get('girchi_notifications');
+  }
+
+  /**
+   * Main command.
+   *
+   * @command girchi_donations:default-aim
+   * @aliases default-aim
+   */
+  public function default_aim_user() {
+    try {
+      $user = $this->configFactory->get('om_site_settings.site_settings')->get('default_receiver');
+      $taxonomy_storage = $this->entityTypeManager->getStorage('taxonomy_term');
+      $tid = $taxonomy_storage->getQuery()
+        ->condition('vid', 'donation_issues')
+        ->execute();
+      $terms = $taxonomy_storage->loadMultiple($tid);
+      foreach ($terms as $term) {
+        $term->set('field_user', $user);
+        $term->save();
+      }
+    }
+    catch (InvalidPluginDefinitionException $e) {
+      $this->loggerFactory->error($e->getMessage());
+
+    }
+    catch (PluginNotFoundException $e) {
+      $this->loggerFactory->error($e->getMessage());
+
+    } catch (EntityStorageException $e) {
+      $this->loggerFactory->error($e->getMessage());
+
+    }
+
+  }
+
+}

--- a/web/modules/custom/girchi_notifications/src/Commands/GirchiNotificationsCommands.php
+++ b/web/modules/custom/girchi_notifications/src/Commands/GirchiNotificationsCommands.php
@@ -11,7 +11,7 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drush\Commands\DrushCommands;
 
 /**
- *
+ * Class GirchiNotificationsCommands.
  */
 class GirchiNotificationsCommands extends DrushCommands {
   /**
@@ -59,7 +59,7 @@ class GirchiNotificationsCommands extends DrushCommands {
    * @command girchi_donations:default-aim
    * @aliases default-aim
    */
-  public function default_aim_user() {
+  public function defaultAimUser() {
     try {
       $user = $this->configFactory->get('om_site_settings.site_settings')->get('default_receiver');
       $taxonomy_storage = $this->entityTypeManager->getStorage('taxonomy_term');
@@ -79,7 +79,8 @@ class GirchiNotificationsCommands extends DrushCommands {
     catch (PluginNotFoundException $e) {
       $this->loggerFactory->error($e->getMessage());
 
-    } catch (EntityStorageException $e) {
+    }
+    catch (EntityStorageException $e) {
       $this->loggerFactory->error($e->getMessage());
 
     }

--- a/web/modules/custom/girchi_notifications/src/Constants/NotificationConstants.php
+++ b/web/modules/custom/girchi_notifications/src/Constants/NotificationConstants.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\girchi_notifications\Constants;
+
+/**
+ * Class NotificationConstants.
+ */
+final class NotificationConstants {
+  const DONATION = 'დონაცია';
+  const PARTY_LIST = 'პარტიული სია';
+  const REFERRAL = 'რეფერალი';
+  const DONATION_EN = 'donation';
+  const PARTY_LIST_EN = 'party list';
+  const REFERRAL_EN = 'referral';
+
+}

--- a/web/modules/custom/girchi_notifications/src/Controller/NotificationController.php
+++ b/web/modules/custom/girchi_notifications/src/Controller/NotificationController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\girchi_notifications\Controller;
+
+/**
+ * Class NotificationController.
+ */
+class NotificationController {
+
+  /**
+   * Notifications.
+   */
+  public function notifications() {
+    return [
+      '#type' => 'markup',
+      '#theme' => 'girchi_notifications',
+    ];
+
+  }
+
+}

--- a/web/modules/custom/girchi_notifications/src/GetUserInfoService.php
+++ b/web/modules/custom/girchi_notifications/src/GetUserInfoService.php
@@ -25,7 +25,7 @@ class GetUserInfoService {
   protected $loggerFactory;
 
   /**
-   * Constructs a new SummaryGedCalculationService object.
+   * Constructs a new GetUserInfoService object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   Entity type manager.
@@ -46,25 +46,24 @@ class GetUserInfoService {
   public function getUserInfo($uid) {
     try {
       $user = $this->entityTypeManager->getStorage('user')->load($uid);
-      $user_name = $user->get('field_first_name')->value;
-      $user_surname = $user->get('field_last_name')->value;
-      $full_name = $user_name ? $user_name . ' ' . $user_surname : '';
-      if ($user->get('user_picture')->entity) {
-        $style = $user->get('user_picture')->entity->getFileUri();
-        $user_picture = file_create_url($style);
+      if (!empty($user)) {
+        $user_name = $user->get('field_first_name')->value;
+        $user_surname = $user->get('field_last_name')->value;
+        $full_name = $user_name ? $user_name . ' ' . $user_surname : '';
+        if ($user->get('user_picture')->entity) {
+          $style = $user->get('user_picture')->entity->getFileUri();
+          $user_picture = file_create_url($style);
+        }
+        else {
+          $user_picture = file_create_url(drupal_get_path('theme', 'girchi') . '/images/avatar.png');
+        }
+
+        return [
+          'uid' => $user->id(),
+          'full_name' => $full_name,
+          'image' => $user_picture,
+        ];
       }
-      else {
-        $user_picture = file_create_url(drupal_get_path('theme', 'girchi') . '/images/avatar.png');
-      }
-
-      $user_info = [
-        'uid' => $user->id(),
-        'full_name' => $full_name,
-        'image' => $user_picture,
-      ];
-
-      return $user_info;
-
     }
     catch (InvalidPluginDefinitionException $e) {
       $this->loggerFactory->error($e->getMessage());

--- a/web/modules/custom/girchi_notifications/src/GetUserInfoService.php
+++ b/web/modules/custom/girchi_notifications/src/GetUserInfoService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\girchi_notifications;
+
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactory;
+
+/**
+ * Class GetUserInfoService.
+ */
+class GetUserInfoService {
+  /**
+   * Entity type Manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+  /**
+   * Logger Factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   */
+  protected $loggerFactory;
+
+  /**
+   * Constructs a new SummaryGedCalculationService object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   Entity type manager.
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerFactory
+   *   Logger messages.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, LoggerChannelFactory $loggerFactory) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->loggerFactory = $loggerFactory->get('girchi_notifications');
+  }
+
+  /**
+   * Get user into.
+   *
+   * @return array|null
+   *   user_info.
+   */
+  public function getUserInfo($uid) {
+    try {
+      $user = $this->entityTypeManager->getStorage('user')->load($uid);
+      $user_name = $user->get('field_first_name')->value;
+      $user_surname = $user->get('field_last_name')->value;
+      $full_name = $user_name ? $user_name . ' ' . $user_surname : '';
+      if ($user->get('user_picture')->entity) {
+        $style = $user->get('user_picture')->entity->getFileUri();
+        $user_picture = file_create_url($style);
+      }
+      else {
+        $user_picture = file_create_url(drupal_get_path('theme', 'girchi') . '/images/avatar.png');
+      }
+
+      $user_info = [
+        'uid' => $user->id(),
+        'full_name' => $full_name,
+        'image' => $user_picture,
+      ];
+
+      return $user_info;
+
+    }
+    catch (InvalidPluginDefinitionException $e) {
+      $this->loggerFactory->error($e->getMessage());
+    }
+    catch (PluginNotFoundException $e) {
+      $this->loggerFactory->error($e->getMessage());
+    }
+    return [];
+
+  }
+
+}

--- a/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
+++ b/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
@@ -6,6 +6,8 @@ use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\girchi_donations\Entity\Donation;
+use Drupal\girchi_notifications\Constants\NotificationConstants;
 
 /**
  * Class NotifyDonationService.
@@ -32,6 +34,13 @@ class NotifyDonationService {
   protected $notifyUserService;
 
   /**
+   * GetUserInfoService;.
+   *
+   * @var \Drupal\girchi_notifications\GetUserInfoService
+   */
+  protected $getUserInfoService;
+
+  /**
    * Constructs a new SummaryGedCalculationService object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
@@ -39,49 +48,63 @@ class NotifyDonationService {
    * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerFactory
    *   Logger messages.
    * @param \Drupal\girchi_notifications\NotifyUserService $notifyUserService
-   *   Notify user service.
+   *   NotifyUser service.
+   * @param \Drupal\girchi_notifications\GetUserInfoService $getUserInfoService
+   *   GetUserInfo service.
    */
   public function __construct(EntityTypeManagerInterface $entityTypeManager,
                               LoggerChannelFactory $loggerFactory,
-                              NotifyUserService $notifyUserService) {
+                              NotifyUserService $notifyUserService,
+                              GetUserInfoService $getUserInfoService) {
     $this->entityTypeManager = $entityTypeManager;
     $this->loggerFactory = $loggerFactory->get('girchi_notifications');
     $this->notifyUserService = $notifyUserService;
+    $this->getUserInfoService = $getUserInfoService;
   }
 
   /**
    * Function to get assigned user from Donation Aim.
    *
-   * @param int $type
-   *   Type.
-   * @param array $invoker
-   *   Invoker is person who caused notification.
-   * @param int $amount
-   *   Amount.
-   * @param int $user_id
-   *   User id.
-   * @param string $donation_aim
-   *   Donation aim.
+   * @param \Drupal\girchi_donations\Entity\Donation $donation
+   *   Donation.
    */
-  public function notifyDonation($type, array $invoker, $amount, $user_id, $donation_aim) {
+  public function notifyDonation(Donation $donation) {
     try {
-      $notification_type = 'დონაცია';
-      $notification_type_en = 'donation';
+      $type = !empty($donation->getAim()) ? 1 : 2;
+      $user_id = $donation->getUser()->id();
+      // $invoker is person who caused notification.
+      $invoker = $this->getUserInfoService->getUserInfo($user_id);
+      $amount = $donation->getAmount();
+      $notification_type = NotificationConstants::DONATION;
+      $notification_type_en = NotificationConstants::DONATION_EN;
       if ($type == 1) {
+        $donation_aim = $donation->getAim()->id();
         $taxonomy_storage = $this->entityTypeManager->getStorage('taxonomy_term')->load($donation_aim);
         $aim_name = $taxonomy_storage->get('name')->value;
         foreach ($taxonomy_storage->get('field_user') as $assigned_user) {
-          $text = "${invoker['full_name']}-მ დააფინანსა ${aim_name} ${amount} ლარით.";
-          $text_en = "${invoker['full_name']} donated ${amount} GEL to ${aim_name}.";
+          if ($user_id == 0) {
+            $text = "ანონიმურმა მომხმარებელმა დააფინანსა ${aim_name} ${amount} ლარით.";
+            $text_en = "Anonymous user has donated ${amount} GEL to ${aim_name}.";
+          }
+          else {
+            $text = "${invoker['full_name']}-მ დააფინანსა ${aim_name} ${amount} ლარით.";
+            $text_en = "${invoker['full_name']} donated ${amount} GEL to ${aim_name}.";
+          }
           $this->notifyUserService->notifyUser($assigned_user->target_id, $invoker, $notification_type, $notification_type_en, $text, $text_en);
         }
       }
       else {
-        $text = "${invoker['full_name']}-მ  დაგაფინანსათ ${amount} ლარით.";
-        $text_en = "${invoker['full_name']} donated you ${amount} GEL.";
-        $this->notifyUserService->notifyUser($user_id, $invoker, $notification_type, $notification_type_en, $text, $text_en);
+        $politician_id = $donation->getPolitician()->id();
+        if ($user_id == 0) {
+          $text = "ანონიმურმა მომხმარებელმა დაგაფინანსათ ${amount} ლარით.";
+          $text_en = "Anonymous user has donated you ${amount} GEL.";
+        }
+        else {
+          $text = "${invoker['full_name']}-მ  დაგაფინანსათ ${amount} ლარით.";
+          $text_en = "${invoker['full_name']} donated you ${amount} GEL.";
+        }
+        $this->notifyUserService->notifyUser($politician_id, $invoker, $notification_type, $notification_type_en, $text, $text_en);
       }
-
     }
     catch (InvalidPluginDefinitionException $e) {
       $this->loggerFactory->error($e->getMessage());

--- a/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
+++ b/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
@@ -80,17 +80,19 @@ class NotifyDonationService {
       if ($type == 1) {
         $donation_aim = $donation->getAim()->id();
         $taxonomy_storage = $this->entityTypeManager->getStorage('taxonomy_term')->load($donation_aim);
-        $aim_name = $taxonomy_storage->get('name')->value;
-        foreach ($taxonomy_storage->get('field_user') as $assigned_user) {
-          if ($user_id == 0) {
-            $text = "ანონიმურმა მომხმარებელმა დააფინანსა ${aim_name} ${amount} ლარით.";
-            $text_en = "Anonymous user has donated ${amount} GEL to ${aim_name}.";
+        if (!empty($taxonomy_storage)) {
+          $aim_name = $taxonomy_storage->get('name')->value;
+          foreach ($taxonomy_storage->get('field_user') as $assigned_user) {
+            if ($user_id == 0) {
+              $text = "ანონიმურმა მომხმარებელმა დააფინანსა ${aim_name} ${amount} ლარით.";
+              $text_en = "Anonymous user has donated ${amount} GEL to ${aim_name}.";
+            }
+            else {
+              $text = "${invoker['full_name']}-მ დააფინანსა ${aim_name} ${amount} ლარით.";
+              $text_en = "${invoker['full_name']} donated ${amount} GEL to ${aim_name}.";
+            }
+            $this->notifyUserService->notifyUser($assigned_user->target_id, $invoker, $notification_type, $notification_type_en, $text, $text_en);
           }
-          else {
-            $text = "${invoker['full_name']}-მ დააფინანსა ${aim_name} ${amount} ლარით.";
-            $text_en = "${invoker['full_name']} donated ${amount} GEL to ${aim_name}.";
-          }
-          $this->notifyUserService->notifyUser($assigned_user->target_id, $invoker, $notification_type, $notification_type_en, $text, $text_en);
         }
       }
       else {

--- a/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
+++ b/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
@@ -70,12 +70,12 @@ class NotifyDonationService {
    *   Invoker is person who caused notification.
    * @param int $amount
    *   Amount.
-   * @param int $user
-   *   User.
-   * @param int $donation_aim
+   * @param int $user_id
+   *   User id.
+   * @param string $donation_aim
    *   Donation aim.
    */
-  public function notifyDonation($type, array $invoker, $amount, $user, $donation_aim) {
+  public function notifyDonation($type, array $invoker, $amount, $user_id, $donation_aim) {
     try {
       if ($type == 1) {
         $taxonomy_storage = $this->entityTypeManager->getStorage('taxonomy_term')->load($donation_aim);
@@ -87,7 +87,7 @@ class NotifyDonationService {
       }
       else {
         $text = $this->stringTranslation->translate("${invoker['full_name']} donated you ${amount} GEL");
-        $this->notifyUserService->notifyUser($user, $invoker, 'donation', $text);
+        $this->notifyUserService->notifyUser($user_id, $invoker, 'donation', $text);
       }
 
     }

--- a/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
+++ b/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
@@ -79,9 +79,10 @@ class NotifyDonationService {
     try {
       if ($type == 1) {
         $taxonomy_storage = $this->entityTypeManager->getStorage('taxonomy_term')->load($donation_aim);
+        $aim_name = $taxonomy_storage->get('name')->value;
         foreach ($taxonomy_storage->get('field_user') as $assigned_user) {
-          $text = $this->stringTranslation->translate("${invoker['full_name']} donated ${amount} GEL to ${$donation_aim}");
-          $this->notifyUserService->notifyUser($assigned_user, $invoker, 'donation', $text);
+          $text = "${invoker['full_name']} donated ${amount} GEL to ${aim_name}";
+          $this->notifyUserService->notifyUser($assigned_user->target_id, $invoker, 'donation', $text);
         }
       }
       else {

--- a/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
+++ b/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\girchi_notifications;
+
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Class NotifyDonationService.
+ */
+class NotifyDonationService {
+  /**
+   * Entity type Manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+  /**
+   * Logger Factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   */
+  protected $loggerFactory;
+
+  /**
+   * NotifyUserService.
+   *
+   * @var \Drupal\girchi_notifications\NotifyUserService
+   */
+  protected $notifyUserService;
+
+  /**
+   * Translation.
+   *
+   * @var \Drupal\Core\StringTranslation\TranslationInterface
+   */
+  protected $stringTranslation;
+
+  /**
+   * Constructs a new SummaryGedCalculationService object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   Entity type manager.
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerFactory
+   *   Logger messages.
+   * @param \Drupal\girchi_notifications\NotifyUserService $notifyUserService
+   *   Notify user service.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $translation
+   *   Translation.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager,
+                              LoggerChannelFactory $loggerFactory,
+                              NotifyUserService $notifyUserService,
+                              TranslationInterface $translation) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->loggerFactory = $loggerFactory->get('girchi_notifications');
+    $this->notifyUserService = $notifyUserService;
+    $this->stringTranslation = $translation;
+  }
+
+  /**
+   * Function to get assigned user from Donation Aim.
+   *
+   * @param int $type
+   *   Type.
+   * @param array $invoker
+   *   Invoker is person who caused notification.
+   * @param int $amount
+   *   Amount.
+   * @param int $user
+   *   User.
+   * @param int $donation_aim
+   *   Donation aim.
+   */
+  public function notifyDonation($type, array $invoker, $amount, $user, $donation_aim) {
+    try {
+      if ($type == 1) {
+        $taxonomy_storage = $this->entityTypeManager->getStorage('taxonomy_term')->load($donation_aim);
+        foreach ($taxonomy_storage->get('field_user') as $assigned_user) {
+          $text = $this->stringTranslation->translate("${invoker['full_name']} donated ${amount} GEL to ${$donation_aim}");
+          $this->notifyUserService->notifyUser($assigned_user, $invoker, 'donation', $text);
+        }
+      }
+      else {
+        $text = $this->stringTranslation->translate("${invoker['full_name']} donated you ${amount} GEL");
+        $this->notifyUserService->notifyUser($user, $invoker, 'donation', $text);
+      }
+
+    }
+    catch (InvalidPluginDefinitionException $e) {
+      $this->loggerFactory->error($e->getMessage());
+    }
+    catch (PluginNotFoundException $e) {
+      $this->loggerFactory->error($e->getMessage());
+    }
+
+  }
+
+}

--- a/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
+++ b/web/modules/custom/girchi_notifications/src/NotifyDonationService.php
@@ -6,7 +6,6 @@ use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactory;
-use Drupal\Core\StringTranslation\TranslationInterface;
 
 /**
  * Class NotifyDonationService.
@@ -33,13 +32,6 @@ class NotifyDonationService {
   protected $notifyUserService;
 
   /**
-   * Translation.
-   *
-   * @var \Drupal\Core\StringTranslation\TranslationInterface
-   */
-  protected $stringTranslation;
-
-  /**
    * Constructs a new SummaryGedCalculationService object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
@@ -48,17 +40,13 @@ class NotifyDonationService {
    *   Logger messages.
    * @param \Drupal\girchi_notifications\NotifyUserService $notifyUserService
    *   Notify user service.
-   * @param \Drupal\Core\StringTranslation\TranslationInterface $translation
-   *   Translation.
    */
   public function __construct(EntityTypeManagerInterface $entityTypeManager,
                               LoggerChannelFactory $loggerFactory,
-                              NotifyUserService $notifyUserService,
-                              TranslationInterface $translation) {
+                              NotifyUserService $notifyUserService) {
     $this->entityTypeManager = $entityTypeManager;
     $this->loggerFactory = $loggerFactory->get('girchi_notifications');
     $this->notifyUserService = $notifyUserService;
-    $this->stringTranslation = $translation;
   }
 
   /**
@@ -77,17 +65,21 @@ class NotifyDonationService {
    */
   public function notifyDonation($type, array $invoker, $amount, $user_id, $donation_aim) {
     try {
+      $notification_type = 'დონაცია';
+      $notification_type_en = 'donation';
       if ($type == 1) {
         $taxonomy_storage = $this->entityTypeManager->getStorage('taxonomy_term')->load($donation_aim);
         $aim_name = $taxonomy_storage->get('name')->value;
         foreach ($taxonomy_storage->get('field_user') as $assigned_user) {
-          $text = "${invoker['full_name']} donated ${amount} GEL to ${aim_name}";
-          $this->notifyUserService->notifyUser($assigned_user->target_id, $invoker, 'donation', $text);
+          $text = "${invoker['full_name']}-მ დააფინანსა ${aim_name} ${amount} ლარით.";
+          $text_en = "${invoker['full_name']} donated ${amount} GEL to ${aim_name}.";
+          $this->notifyUserService->notifyUser($assigned_user->target_id, $invoker, $notification_type, $notification_type_en, $text, $text_en);
         }
       }
       else {
-        $text = $this->stringTranslation->translate("${invoker['full_name']} donated you ${amount} GEL");
-        $this->notifyUserService->notifyUser($user_id, $invoker, 'donation', $text);
+        $text = "${invoker['full_name']}-მ  დაგაფინანსათ ${amount} ლარით.";
+        $text_en = "${invoker['full_name']} donated you ${amount} GEL.";
+        $this->notifyUserService->notifyUser($user_id, $invoker, $notification_type, $notification_type_en, $text, $text_en);
       }
 
     }

--- a/web/modules/custom/girchi_notifications/src/NotifyUserService.php
+++ b/web/modules/custom/girchi_notifications/src/NotifyUserService.php
@@ -107,11 +107,8 @@ class NotifyUserService {
       $host = $_ENV['HOST'];
       $result = $this->httpClient->post($host, $options);
 
-      if ($result->getStatusCode() == 200) {
+      if ($result->getStatusCode() == 200 || $result->getStatusCode() == 201) {
         return TRUE;
-      }
-      else {
-        $this->loggerFactory->error($result->getStatusCode());
       }
       return FALSE;
 

--- a/web/modules/custom/girchi_notifications/src/NotifyUserService.php
+++ b/web/modules/custom/girchi_notifications/src/NotifyUserService.php
@@ -71,46 +71,54 @@ class NotifyUserService {
    *   Response.
    */
   public function notifyUser($user_id, array $invoker, $type, $type_en, $text, $text_en) {
-    $host = $this->request->getCurrentRequest()->getHost();
-    $link = '';
+    try {
+      $host = $this->request->getCurrentRequest()->getHost();
+      $link = '';
 
-    if ($type_en == NotificationConstants::DONATION_EN) {
-      $link = $host . '/user/' . $invoker['uid'];
-    }
-    elseif ($type_en == NotificationConstants::REFERRAL_EN) {
-      $link = $host . '/user/' . $user_id . '?show_referral_modal=true';
-    }
-    elseif ($type_en == NotificationConstants::PARTY_LIST_EN) {
-      $link = $host . '/user/' . $invoker['uid'] . '?show_partyList_modal=true';
-    }
+      if ($type_en == NotificationConstants::DONATION_EN) {
+        $link = $host . '/user/' . $invoker['uid'];
+      }
+      elseif ($type_en == NotificationConstants::REFERRAL_EN) {
+        $link = $host . '/user/' . $user_id . '?show_referral_modal=true';
+      }
+      elseif ($type_en == NotificationConstants::PARTY_LIST_EN) {
+        $link = $host . '/user/' . $invoker['uid'] . '?show_partyList_modal=true';
+      }
 
-    $notification = [
-      'title' => $type,
-      'title_en' => $type_en,
-      'desc' => $text,
-      'desc_en' => $text_en,
-      'type' => $type_en,
-      'user' => $user_id,
-      'link' => $link,
-      'photoUrl' => $invoker['image'],
-    ];
-    $encoded_notification = json::encode($notification);
-    $options = [
-      'method' => 'POST',
-      'body' => $encoded_notification,
-      'headers' => ['Content-Type' => 'application/json'],
-    ];
+      $notification = [
+        'title' => $type,
+        'title_en' => $type_en,
+        'desc' => $text,
+        'desc_en' => $text_en,
+        'type' => $type_en,
+        'user' => $user_id,
+        'link' => $link,
+        'photoUrl' => $invoker['image'],
+      ];
+      $encoded_notification = json::encode($notification);
+      $options = [
+        'method' => 'POST',
+        'body' => $encoded_notification,
+        'headers' => ['Content-Type' => 'application/json'],
+      ];
 
-    $dotEnv = new Dotenv();
-    $dotEnv->load('modules/custom/girchi_notifications/Credentials/.cred.env');
-    $host = $_ENV['HOST'];
-    $result = $this->httpClient->post($host, $options);
+      $dotEnv = new Dotenv();
+      $dotEnv->load('modules/custom/girchi_notifications/Credentials/.cred.env');
+      $host = $_ENV['HOST'];
+      $result = $this->httpClient->post($host, $options);
 
-    if ($result->getStatusCode() == 200) {
-      return TRUE;
+      if ($result->getStatusCode() == 200) {
+        return TRUE;
+      }
+      else {
+        $this->loggerFactory->error($result->getStatusCode());
+      }
+      return FALSE;
+
     }
-    else {
-      return $this->loggerFactory->error($result->getStatusCode());
+    catch (\Exception $e) {
+      $this->loggerFactory->error($e->getMessage());
+
     }
 
   }

--- a/web/modules/custom/girchi_notifications/src/NotifyUserService.php
+++ b/web/modules/custom/girchi_notifications/src/NotifyUserService.php
@@ -72,17 +72,17 @@ class NotifyUserService {
    */
   public function notifyUser($user_id, array $invoker, $type, $type_en, $text, $text_en) {
     try {
-      $host = $this->request->getCurrentRequest()->getHost();
+      $url = $this->request->getCurrentRequest()->getSchemeAndHttpHost();
       $link = '';
 
       if ($type_en == NotificationConstants::DONATION_EN) {
-        $link = $host . '/user/' . $invoker['uid'];
+        $link = $url . '/user/' . $invoker['uid'];
       }
       elseif ($type_en == NotificationConstants::REFERRAL_EN) {
-        $link = $host . '/user/' . $user_id . '?show_referral_modal=true';
+        $link = $url . '/user/' . $user_id . '?show_referral_modal=true';
       }
       elseif ($type_en == NotificationConstants::PARTY_LIST_EN) {
-        $link = $host . '/user/' . $invoker['uid'] . '?show_partyList_modal=true';
+        $link = $url . '/user/' . $invoker['uid'] . '?show_partyList_modal=true';
       }
 
       $notification = [

--- a/web/modules/custom/girchi_notifications/src/NotifyUserService.php
+++ b/web/modules/custom/girchi_notifications/src/NotifyUserService.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\girchi_notifications;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class NotifyUserService.
+ */
+class NotifyUserService {
+  /**
+   * Logger Factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   */
+  protected $loggerFactory;
+
+
+  /**
+   * Request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $request;
+
+  /**
+   * Constructs a new SummaryGedCalculationService object.
+   *
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerFactory
+   *   Logger messages.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request
+   *   Request.
+   */
+  public function __construct(LoggerChannelFactory $loggerFactory, RequestStack $request) {
+    $this->loggerFactory = $loggerFactory->get('girchi_notifications');
+    $this->request = $request;
+  }
+
+  /**
+   * Notify user.
+   *
+   * @param int $user_id
+   *   User id.
+   * @param array $invoker
+   *   Invoker is person who caused notification.
+   * @param string $type
+   *   Type.
+   * @param string $text
+   *   Text.
+   */
+  public function notifyUser($user_id, array $invoker, $type, $text) {
+    $host = $this->request->getCurrentRequest()->getHost();
+    $link = '';
+
+    if ($type == 'donation') {
+      $link = $host . '/user/' . $invoker['uid'];
+    }
+    elseif ($type == 'referral') {
+      $link = $host . '/user/' . $user_id . '?show_referral_modal=true';
+    }
+    elseif ($type == 'party_list') {
+      $link = $host . '/user/' . $invoker['uid'] . '?show_partyList_modal=true';
+    }
+
+    $notification = [
+      'text' => $text,
+      'user' => $user_id,
+      'link' => $link,
+      'photoUrl' => $invoker['image'],
+      'type' => $type,
+    ];
+    $encoded_notification = json::encode($notification);
+
+    $options = [
+      'method' => 'POST',
+      'data' => $encoded_notification,
+      'headers' => ['Content-Type' => 'application/json'],
+    ];
+
+    // TODO::Dependency injection!!
+    $result = \Drupal::httpClient()->post('notifications.girchi.docker.localhost/notifications/', $options);
+
+    if ($result->getStatusCode() == 200) {
+      return TRUE;
+    }
+    else {
+      return $this->loggerFactory->error($result->getStatusCode());
+    }
+
+  }
+
+}

--- a/web/modules/custom/girchi_notifications/templates/girchi-notifications.html.twig
+++ b/web/modules/custom/girchi_notifications/templates/girchi-notifications.html.twig
@@ -1,0 +1,27 @@
+<div{{ attributes.addClass(classes) }}>
+    <div class="row flex-column-reverse flex-lg-row">
+        <div class="col-md-12 col-lg-3 order-1 order-lg-0">
+            {{ print_block('userprofile') }}
+            {{ print_block('useraccountmenu') }}
+        </div>
+        <div class="col-md-12 col-lg-9">
+            {{ print_block('politicianblock') }}
+            <!-- Start of card -->
+            <div class="card mt-0 mt-md-3 mt-lg-0 mb-2 mb-lg-3 overflow-hidden">
+                <div
+                    class="d-flex border-bottom flex-column flex-md-row px-3 px-md-4 py-3 align-items-md-center">
+                    <h6 class="text-uppercase font-weight-bold m-0">
+                        {{ 'Notifications'|t}}
+                    </h6>
+                </div>
+                <!-- Start of notifications -->
+                <div>
+                    <!-- Start card -->
+                    <div class="card border overflow-hidden" id="notifications">
+                    </div>
+                </div>
+            </div>
+            <!-- End of card -->
+        </div>
+    </div>
+</div>

--- a/web/modules/custom/girchi_users/girchi_users.module
+++ b/web/modules/custom/girchi_users/girchi_users.module
@@ -199,7 +199,7 @@ function girchi_users_user_presave(EntityInterface $user) {
 
       // Inform user that someone removed them from referrals.
       if (!empty($original_referral_id)) {
-        $text = "${getUserInfo['full_name']} ამოგშალათ რეფერალებიდან.";
+        $text = "${getUserInfo['full_name']}-მ ამოგშალათ რეფერალებიდან.";
         $text_en = "${getUserInfo['full_name']} removed you from referral.";
         $notifyUserService->notifyUser($original_referral_id, $getUserInfo, $type, $type_en, $text, $text_en);
       }

--- a/web/modules/custom/girchi_users/girchi_users.module
+++ b/web/modules/custom/girchi_users/girchi_users.module
@@ -5,6 +5,7 @@
  * Contains girchi_users.module.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
@@ -149,5 +150,61 @@ function girchi_users_pass_reset_custom_submit(array $form, FormStateInterface $
   $url .= '?pass-reset=success';
   $response = new RedirectResponse($url);
   $response->send();
+
+}
+
+/**
+ * Implements hook_user_insert().
+ */
+function girchi_users_user_insert(EntityInterface $user) {
+  // Notify user that recently created user
+  // Chose them as their referral.
+  if (!empty($user->get('field_referral')->target_id)) {
+    $referral_id = $user->get('field_referral')->target_id;
+    /** @var \Drupal\girchi_notifications\NotifyUserService $notifyUserService */
+    $notifyUserService = \Drupal::service('girchi_notifications.notify_user');
+    $getUserInfo = [
+      'full_name' => $user->name->value,
+      'image' => file_create_url(drupal_get_path('theme', 'girchi') . '/images/avatar.png'),
+    ];
+    $text = "${getUserInfo['full_name']}-მ მოგნიშნათ თავის რეფერალად.";
+    $text_en = "${getUserInfo['full_name']} tagged you as referral.";
+    $type = 'რეფერალი';
+    $type_en = 'referral';
+    $notifyUserService->notifyUser($referral_id, $getUserInfo, $type, $type_en, $text, $text_en);
+  }
+
+}
+
+/**
+ * Implements hook_user_presave().
+ */
+function girchi_users_user_presave(EntityInterface $user) {
+  if (!$user->isNew()) {
+    $original_referral_id = !empty($user->original->get('field_referral')->target_id) ? $user->original->get('field_referral')->target_id : '';
+    $referral_id = !empty($user->get('field_referral')->target_id) ? $user->get('field_referral')->target_id : '';
+    if (!empty($referral_id) && $original_referral_id != $referral_id) {
+      $user_id = $user->id();
+      /** @var \Drupal\girchi_notifications\GetUserInfoService $getUserInfoService */
+      $getUserInfoService = \Drupal::service('girchi_notifications.get_user_info');
+      /** @var \Drupal\girchi_notifications\NotifyUserService $notifyUserService */
+      $notifyUserService = \Drupal::service('girchi_notifications.notify_user');
+      $getUserInfo = $getUserInfoService->getUserInfo($user_id);
+      // Notify user that someone chose them as their referral.
+      $text = "${getUserInfo['full_name']}-მ მოგნიშნათ თავის რეფერალად.";
+      $text_en = "${getUserInfo['full_name']} tagged you as referral";
+      $type = 'რეფერალი';
+      $type_en = 'referral';
+      $notifyUserService->notifyUser($referral_id, $getUserInfo, $type, $type_en, $text, $text_en);
+
+      // Inform user that someone removed them from referrals.
+      if (!empty($original_referral_id)) {
+        $text = "${getUserInfo['full_name']} ამოგშალათ რეფერალებიდან.";
+        $text_en = "${getUserInfo['full_name']} removed you from referral.";
+        $notifyUserService->notifyUser($original_referral_id, $getUserInfo, $type, $type_en, $text, $text_en);
+      }
+
+    }
+  }
 
 }

--- a/web/modules/custom/girchi_users/girchi_users.module
+++ b/web/modules/custom/girchi_users/girchi_users.module
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+use Drupal\girchi_notifications\Constants\NotificationConstants;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -193,8 +194,8 @@ function girchi_users_user_presave(EntityInterface $user) {
       // Notify user that someone chose them as their referral.
       $text = "${getUserInfo['full_name']}-მ მოგნიშნათ თავის რეფერალად.";
       $text_en = "${getUserInfo['full_name']} tagged you as referral";
-      $type = 'რეფერალი';
-      $type_en = 'referral';
+      $type = NotificationConstants::REFERRAL;
+      $type_en = NotificationConstants::REFERRAL_EN;
       $notifyUserService->notifyUser($referral_id, $getUserInfo, $type, $type_en, $text, $text_en);
 
       // Inform user that someone removed them from referrals.

--- a/web/modules/custom/girchi_users/src/EventSubscriber/AuthenticationSubscriber.php
+++ b/web/modules/custom/girchi_users/src/EventSubscriber/AuthenticationSubscriber.php
@@ -86,6 +86,8 @@ class AuthenticationSubscriber implements EventSubscriberInterface {
     }
   }
 
+
+
   /**
    * On KernelEvent response.
    *
@@ -94,20 +96,20 @@ class AuthenticationSubscriber implements EventSubscriberInterface {
    */
   public function onResponse(FilterResponseEvent $event) {
     $host = $this->request->getCurrentRequest()->getHost();
+    $url = str_replace("www","",$host);
     if (!empty($this->request->getCurrentRequest()->getSession()->get('g-u-at'))) {
       $jwt = $this->request->getCurrentRequest()->getSession()->get('g-u-at');
       $refresh_token = $this->request->getCurrentRequest()->getSession()->get('g-u-rt');
-      $jwt_cookie = new Cookie('g-u-at', $jwt, time() + 18000, '', $host, FALSE, FALSE);
-      $refresh_token_cookie = new Cookie('g-u-rt', $refresh_token, time() + 18000, '', $host, FALSE, FALSE);
+      $jwt_cookie = new Cookie('g-u-at', $jwt, time() + 18000, '', $url, FALSE, FALSE);
+      $refresh_token_cookie = new Cookie('g-u-rt', $refresh_token, time() + 18000, '', $url, FALSE, FALSE);
       $event->getResponse()->headers->setCookie($jwt_cookie);
       $event->getResponse()->headers->setCookie($refresh_token_cookie);
     }
 
     if ($this->accountProxy->isAnonymous() && !empty($this->request->getCurrentRequest()->getSession()->get('g-u-at'))) {
-      $event->getResponse()->headers->clearCookie('g-u-at', '', $host);
-      $event->getResponse()->headers->clearCookie('g-u-rt', '', $host);
+      $event->getResponse()->headers->clearCookie('g-u-at', '', $url);
+      $event->getResponse()->headers->clearCookie('g-u-rt', '', $url);
     }
 
   }
-
 }

--- a/web/themes/custom/girchi/js/global.js
+++ b/web/themes/custom/girchi/js/global.js
@@ -112,6 +112,9 @@ $(document).ready(function() {
     if(urlParams.has('show_referral_modal') && urlParams.get('show_referral_modal')=='true'){
         $('#referralModal').modal('show');
     }
+    if(urlParams.has('show_partyList_modal') && urlParams.get('show_partyList_modal')=='true'){
+        $('#fullList').modal('show');
+    }
 
     if(window.location.search == '?pass-reset=success'){
         $("#user-login-form").prepend(`<div class="alert alert-success">${Drupal.t("Your password has been successfully changed. Please log in into your account with new password.")} </div>`);


### PR DESCRIPTION
#691
## აღწერა
შეიქმნა ნოთიფიკაციის გასაგზავნი სერვისი. ნოთიფიკაციები იგზავნება შემდეგ მოქნედებებზე:
 -  ნოთიფიკაცია იგზავნება როდესაც აფინანსებენ მიზანს. `donation issue` ტაქსონომი თერმს დაემატა ახალი ველი, რომელიც მიუთითებს იმაზე თუ ვის უნდა მიუვიდეს ნოთიფიკაცია კონკრეტულ დაფინანსებულ მიზანზე. თუ არავინ არ იქნება მონიშნული, ყველა ესეთი ნოთიფიკაცია მისდის ჯგერეს.
- ნოთიფიკაცია მიდის პოლიტიკოსთან, როდესაც დააფინანსებენ მას.
- როცა **მოგნიშნავენ** / **წაგშლიან** რეფერალებიდან.
- როდესაც პარტიულ სიაში **გამატებენ**/**გშლიან**/**პროცენტს** **გიზრდიან**/**პროცენტს გაკლებენ.**

## ინსტალაცია
`make drush cim`
`site setting`-ში DEFAULT NOTIFICATION RECEIVER-ში შეიყვანეთ ის მომხმარებელი ვისაც უნდა მისდიოდეს ნოთიფიკაცია მიზნის დაფინანსებაზე. **ფროდაქშენზე ვწერთ ჯგერეს**.
`make drush default-aim`

## გატესტვა ლოკალურად
web/modules/custom/girchi_notifications/Credentials აქ შექმენით .cred.env და .cred.env.dist-დან დააკოპირეთ მონაცემები.
დაატრიგერეთ ნოთიფიკაცია ზემოთ ჩამოთვლილი ყველა ხერხით და შეამოქმეთ, რომ ბაზაში იყოს ჩაწერილი შესაბამისი ჩანაწერი:
`docker exec -it girchi_notifications_db`
`mongo`
`use notifications`
`db.notifications.find()` 




