### PR TITLE
ტოპ რეფერალების ცვლილება

### DIFF
--- a/web/modules/custom/girchi_leaderboard/templates/lead-partners.html.twig
+++ b/web/modules/custom/girchi_leaderboard/templates/lead-partners.html.twig
@@ -12,7 +12,7 @@
                     role="tab"
                     aria-controls="lead"
                     aria-selected="true"
-                >{{ "Top partners" |t }}</a
+                >{{ "Partners" |t }}</a
                 >
             </li>
             <li class="nav-item col-6">
@@ -24,7 +24,7 @@
                     role="tab"
                     aria-controls="ref"
                     aria-selected="false"
-                >{{ "Top referrals" |t}}</a
+                >{{ "Referrals" |t}}</a
                 >
             </li>
         </ul>
@@ -344,7 +344,7 @@
                     class="modal-title font-size-3 text-uppercase font-weight-bold"
                     id="supportersTitle"
                 >
-                    {{ 'Top partners' | t }}
+                    {{ 'Partners' | t }}
                 </h5>
                 <button
                     type="button"
@@ -442,7 +442,7 @@
                     class="modal-title font-size-3 text-uppercase font-weight-bold"
                     id="supportersTitle"
                 >
-                    {{ 'Top partners' | t }}
+                    {{ 'Partners' | t }}
                 </h5>
                 <button
                     type="button"
@@ -540,7 +540,7 @@
                     class="modal-title font-size-3 text-uppercase font-weight-bold"
                     id="supportersTitle"
                 >
-                    {{ 'Top partners' | t }}
+                    {{ 'Partners' | t }}
                 </h5>
                 <button
                     type="button"
@@ -639,7 +639,7 @@
                     class="modal-title font-size-3 text-uppercase font-weight-bold"
                     id="supportersTitle"
                 >
-                    {{ 'Top partners' | t }}
+                    {{ 'Partners' | t }}
                 </h5>
                 <button
                     type="button"

--- a/web/modules/custom/girchi_leaderboard/templates/lead-partners.html.twig
+++ b/web/modules/custom/girchi_leaderboard/templates/lead-partners.html.twig
@@ -2,7 +2,7 @@
     class="card mt-3 mt-sm-4 mt-md-0 mt-lg-4 font-size-3"
 >
     <div class="p-0 py-md-0 px-xl-4 row font-size-1">
-        <ul class="nav nav-tabs" id="myTab" role="tablist">
+        <ul class="nav nav-tabs w-100" id="myTab" role="tablist">
             <li class="nav-item col-6" >
                 <a
                     class="nav-link font-weight-bold text-uppercase active"

--- a/web/modules/custom/girchi_referral/girchi_referral.module
+++ b/web/modules/custom/girchi_referral/girchi_referral.module
@@ -76,6 +76,7 @@ function girchi_referral_theme($existing, $type, $theme, $path) {
       'variables' =>
         [
           'topReferrals' => NULL,
+          'topReferralsMonthly' => NULL,
         ],
       'template' => 'top-referrals',
     ],

--- a/web/modules/custom/girchi_referral/templates/top-referrals.html.twig
+++ b/web/modules/custom/girchi_referral/templates/top-referrals.html.twig
@@ -1,58 +1,160 @@
-<ul class="list-group list-group-flush mt-2">
-    {% if topReferrals %}
-        {% for key, user in topReferrals  | slice(0, 5) %}
-            <li
-                class=" {{ loop.first ? 'first-ref' : ''  }} list-group-item d-flex align-items-center px-0"
-            >
-                                <span
-                                    class="font-size-6 font-size-xl-7 text-dark-silver mr-2 mr-xl-3"
-                                >{{ key + 1 }}</span
-                                >
-                <div class="d-flex w-100 align-items-center">
-                    <a
-                        href="{{ path('entity.user.canonical', {'user' : user.uid}) }}"
-                        class="rounded-circle overflow-hidden d-inline-block"
-                    >
-                        <img
-                            src= "{{ user.img ? image_style_url(user.img, 'partner_image') : theme_path() ~ "/images/avatar50x50.png"  }}"
-                            class="rounded"
-                            alt="..."
-                        />
-
-                    </a>
-                    <h6
-                        class="text-uppercase line-height-1-2 font-size-3 font-size-xl-base mb-0 mx-2 mx-xl-3"
-                    >
-                        <a
-                            href="{{ path('entity.user.canonical', {'user' : user.uid}) }}"
-                            class="text-decoration-none d-inline-block text-hover-success"
-                        >
-                            {{ user.uid ?  user.user_name : 'Anonymous'|t  }}
-                            <span class="d-block font-weight-bold"
-                            >{{ user.uid ? user.user_surname : 'User'|t }}</span
-                            >
-                        </a>
-                    </h6>
-                    <span
-                        class="text-success font-size-4 font-size-xl-4 font-weight-bold ml-auto"
-                    >{{ user.referral_benefits | ged_long_format }} ₾</span
-                    >
-                </div>
+<div class="tab-content" id="myTabContent">
+    <div class="tab-pane fade show active" id="ref" role="tabpanel" aria-labelledby="ref">
+        <ul class="nav nav-pills my-2" id="myTab" role="tablist">
+            <li class="nav-item">
+                <a
+                    class="nav-link font-weight-bold text-uppercase {{topReferralsMonthly is not empty ? "active" : '' }}"
+                    id="monthly-tab-ref"
+                    data-toggle="tab"
+                    href="#monthly-ref"
+                    role="tab"
+                    aria-controls="monthly-ref"
+                    aria-selected="{{topReferralsMonthly is not empty ? "true" : 'false' }}"
+                >მიმდინარე</a
+                >
             </li>
+            <li class="nav-item">
+                <a
+                    class="nav-link font-weight-bold text-uppercase {{topReferralsMonthly is empty ? "active" : '' }}"
+                    id="total-tab-ref"
+                    data-toggle="tab"
+                    href="#total-ref"
+                    role="tab"
+                    aria-controls="total-ref"
+                    aria-selected="{{topReferralsMonthly is empty ? "true" : 'false' }}"
+                >სულ</a
+                >
+            </li>
+        </ul>
+        <div class="tab-content" id="myTabContent">
+            <div
+                class="tab-pane fade {{topReferralsMonthly is not empty ? "show active" : '' }}"
+                id="monthly-ref"
+                role="tabpanel"
+                aria-labelledby="monthly-tab-ref"
+            >
+                <ul class="list-group list-group-flush mt-2">
+                    {% if topReferralsMonthly %}
+                        {% for key,user in topReferralsMonthly  | slice(0, 5) %}
+                            <li
+                                class=" {{ loop.first ? 'first-ref' : ''  }} list-group-item d-flex align-items-center px-0"
+                            >
+                        <span
+                            class="font-size-6 font-size-xl-7 text-dark-silver mr-2 mr-xl-3"
+                        >{{ loop.index }}</span
+                        >
+                                <div class="d-flex w-100 align-items-center">
+                                    <a
+                                        href="{{ path('entity.user.canonical', {'user' : user.uid}) }}"
+                                        class="rounded-circle overflow-hidden d-inline-block"
+                                    >
+                                        <img
+                                            src= "{{ user.img ? image_style_url(user.img, 'partner_image') : theme_path() ~ "/images/avatar50x50.png"  }}"
+                                            class="rounded"
+                                            alt="..."
+                                        />
 
-        {% endfor %}
-        <a
-            href="#"
-            class="ml-auto card-view-all font-weight-normal text-grey text-decoration-none text-nowrap top-block-arrow"
-            data-toggle="modal"
-            data-target="#topReferralsFullList"
-        >{{ 'Full list'|t }}
-            <i class="icon-arrow-right2 text-dark-silver"></i>
-        </a>
-    {% endif %}
-</ul>
+                                    </a>
+                                    <h6
+                                        class="text-uppercase line-height-1-2 font-size-3 font-size-xl-base mb-0 mx-2 mx-xl-3"
+                                    >
+                                        <a
+                                            href="{{ path('entity.user.canonical', {'user' : user.uid}) }}"
+                                            class="text-decoration-none d-inline-block text-hover-success"
+                                        >
+                                            {{ user.uid ?  user.user_name : 'Anonymous'|t  }}
+                                            <span class="d-block font-weight-bold"
+                                            >{{ user.uid ? user.user_surname : 'User'|t }}</span
+                                            >
+                                        </a>
+                                    </h6>
+                                    <span
+                                        class="text-success font-size-4 font-size-xl-4 font-weight-bold ml-auto"
+                                    >{{ user.referral_benefits > 1 ? user.referral_benefits| ged_long_format  : user.referral_benefits }} ₾</span>
+                                </div>
+                            </li>
 
-{#Top referrals modal#}
+                        {% endfor %}
+                        {% if topReferralsMonthly|length > 5 %}
+                            <a
+                                href="#"
+                                class="ml-auto card-view-all font-weight-normal text-grey text-decoration-none text-nowrap top-block-arrow"
+                                data-toggle="modal"
+                                data-target="#topReferralsMonthly"
+                            >{{ 'Full list'|t }}
+                                <i class="icon-arrow-right2 text-dark-silver"></i>
+                            </a>
+                        {% endif %}
+                    {% endif %}
+
+                </ul>
+            </div>
+            <div
+                class="tab-pane fade {{topReferralsMonthly is empty ? "show active" : '' }}"
+                id="total-ref"
+                role="tabpanel"
+                aria-labelledby="total-tab-ref"
+            >
+                <ul class="list-group list-group-flush mt-2">
+                    {% if topReferrals %}
+                        {% for key,user in topReferrals  | slice(0, 5) %}
+                            <li
+                                class=" {{ loop.first ? 'first-ref' : ''  }} list-group-item d-flex align-items-center px-0"
+                            >
+                        <span
+                            class="font-size-6 font-size-xl-7 text-dark-silver mr-2 mr-xl-3"
+                        >{{ loop.index }}</span
+                        >
+                                <div class="d-flex w-100 align-items-center">
+                                    <a
+                                        href="{{ path('entity.user.canonical', {'user' : user.uid}) }}"
+                                        class="rounded-circle overflow-hidden d-inline-block"
+                                    >
+                                        <img
+                                            src= "{{ user.img ? image_style_url(user.img, 'partner_image') : theme_path() ~ "/images/avatar50x50.png"  }}"
+                                            class="rounded"
+                                            alt="..."
+                                        />
+
+                                    </a>
+                                    <h6
+                                        class="text-uppercase line-height-1-2 font-size-3 font-size-xl-base mb-0 mx-2 mx-xl-3"
+                                    >
+                                        <a
+                                            href="{{ path('entity.user.canonical', {'user' : user.uid}) }}"
+                                            class="text-decoration-none d-inline-block text-hover-success"
+                                        >
+                                            {{ user.uid ?  user.user_name : 'Anonymous'|t  }}
+                                            <span class="d-block font-weight-bold"
+                                            >{{ user.uid ? user.user_surname : 'User'|t }}</span
+                                            >
+                                        </a>
+                                    </h6>
+                                    <span
+                                        class="text-success font-size-4 font-size-xl-4 font-weight-bold ml-auto"
+                                    >{{ user.referral_benefits > 1 ? user.referral_benefits| ged_long_format  : user.referral_benefits }} ₾</span>
+                                </div>
+                            </li>
+
+                        {% endfor %}
+                        {% if topReferrals|length > 5 %}
+                            <a
+                                href="#"
+                                class="ml-auto card-view-all font-weight-normal text-grey text-decoration-none text-nowrap top-block-arrow"
+                                data-toggle="modal"
+                                data-target="#topReferralsFullList"
+                            >{{ 'Full list'|t }}
+                                <i class="icon-arrow-right2 text-dark-silver"></i>
+                            </a>
+                        {% endif %}
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+{#Top referrals full modal#}
 
 <div
     class="modal fade"
@@ -69,7 +171,7 @@
                     class="modal-title font-size-3 text-uppercase font-weight-bold"
                     id="supportersTitle"
                 >
-                    {{ 'Top referrals' | t }}
+                    {{ 'Referrals' | t }}
                 </h5>
                 <button
                     type="button"
@@ -173,6 +275,185 @@
                                                 {{ user.referral_count }} +
                                             </a>
                                         </li>
+                                        {% endif %}
+                                    </ul>
+                                {% else %}
+                                    <ul
+                                        class="list-unstyled m-0 align-items-center d-md-flex"
+                                    >
+                                        {% for i in 0..3 %}
+                                            <li class="align-items-center hidden-referrals">
+                                                <a
+                                                    title="{{ user.referrals[i]['referral_name'] ~ ' ' ~user.referrals[i]['referral_surname'] }}"
+                                                    href="{{ path('entity.user.canonical', {'user' : user.referrals[i]['referral_id']}) }}"
+                                                    class="rounded-circle overflow-hidden d-inline-block m-1 politician-modal"
+                                                >
+                                                    <img
+                                                        src="{{ user.referrals[i]['referral_img'] ? image_style_url(user.referrals[i]['referral_img'],  'avatar_xs') : theme_path() ~ '/images/avatar.png' }}"
+                                                        class="rounded"
+                                                        width="34"
+                                                        alt="..."
+                                                    />
+                                                </a>
+                                            </li>
+                                        {% endfor %}
+                                        <li class="ref-count">
+                                            <a
+                                                href="{{ path('entity.user.canonical', {'user' : user.uid, 'show_referral_modal' : 'true'}) }}"
+                                                class="btn btn-light btn-sm m-1 px-2 bg-hover-success text-hover-white politician-modal"
+                                            >
+                                                {{ user.referral_count - 4 }} +
+                                            </a>
+                                        </li>
+                                        <!-- only for mobile version -->
+                                        <li class="referral-count" >
+                                            <a
+                                                href="{{ path('entity.user.canonical', {'user' : user.uid, 'show_referral_modal' : 'true'}) }}"
+                                                class="btn btn-light btn-sm m-1 px-2 bg-hover-success text-hover-white politician-modal"
+                                            >
+                                                {{ user.referral_count }} +
+                                            </a>
+                                        </li>
+                                    </ul>
+                                {% endif %}
+                            </td>
+
+                            <td class="text-right text-md-center align-middle font-weight-bold">
+                                 <span
+                                     class="text-success font-size-4 font-size-xl-4 font-weight-bold ml-auto"
+                                 >{{ user.referral_benefits > 1 ? user.referral_benefits|ged_long_format  : user.referral_benefits}} ₾</span
+                                 >
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+{#Top referrals monthly modal#}
+
+<div
+    class="modal fade"
+    id="topReferralsMonthly"
+    tabindex="-1"
+    role="dialog"
+    aria-labelledby="fullListTitle"
+    aria-hidden="true"
+>
+    <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+        <div class="modal-content overflow-hidden">
+            <div class="modal-header align-items-center px-3 px-md-4">
+                <h5
+                    class="modal-title font-size-3 text-uppercase font-weight-bold"
+                    id="supportersTitle"
+                >
+                    {{ 'Referrals' | t }}
+                </h5>
+                <button
+                    type="button"
+                    class="close ml-2"
+                    data-dismiss="modal"
+                    aria-label="Close"
+                >
+                    <i
+                        aria-hidden="true"
+                        class="icon-close font-size-3 text-dark-silver"
+                    ></i>
+                </button>
+            </div>
+            <div class="modal-body p-0 table-responsive">
+                <table class="table m-0 table-hover">
+                    <thead>
+                    <tr class="bg-dark-white">
+                        <th
+                            scope="col"
+                            class="align-middle w-auto w-md-80-px text-center text-dark-silver font-size-2 border-0"
+                        >
+                            #
+                        </th>
+                        <th
+                            scope="col"
+                            class="align-middle font-size-1 font-size-md-2 text-dark-silver border-0"
+                        >
+                            {{ "Name" |t }}
+                        </th>
+
+                        <th
+                            scope="col"
+                            class="align-middle font-size-1 font-size-md-2 text-dark-silver border-0 text-center line-height-1-2"
+                        >
+                            {{ 'Referrals' |t }}
+                        </th>
+                        <th
+                            scope="col"
+                            class="align-middle font-size-1 font-size-md-2 text-dark-silver border-0 text-center line-height-1-2"
+                        >
+                            {{ "Benefits" |t  }}
+                        </th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for user in topReferralsMonthly %}
+                        <tr>
+                            <th scope="row" class="pl-3 w-auto w-md-80-px text-center align-middle">
+                                <span class="font-size-4 font-size-xl-5 text-dark-silver font-weight-normal">{{ loop.index }}</span>
+                            </th>
+                            <td class="align-middle">
+                                <div class="d-flex w-100 align-items-center">
+                                    <a
+                                        href="{{ path('entity.user.canonical', {'user' : user.uid}) }}"
+                                        class="rounded-circle overflow-hidden d-none d-md-block">
+                                        <img
+                                            src= "{{ user.img ? image_style_url(user.img, 'partner_image') : theme_path() ~ "/images/avatar50x50.png"  }}"
+                                            class="rounded"
+                                            alt="..."
+                                        />
+                                    </a>
+                                    <h6 class="w-100 w-sm-auto text-uppercase line-height-1-2 font-size-3 font-size-md-3 font-size-xl-base mb-0 mx-0 mx-md-3">
+                                        <a href="{{ path('entity.user.canonical', {'user' : user.uid}) }}" class="d-inline-block text-hover-success">
+                              <span class="text-decoration-none d-inline-block">
+                                <span>{{ user.uid ?  user.user_name : 'Anonymous'|t  }}</span>
+                                <span class="font-weight-bold">{{ user.uid ? user.user_surname : 'User'|t }}</span>
+                              </span>
+                                        </a>
+                                    </h6>
+                                </div>
+                            </td>
+                            <td class="text-right text-md-center align-middle">
+                                {% if user.referral_count <= 4  %}
+                                    <ul
+                                        class="list-unstyled m-0 align-items-center d-md-flex"
+                                    >
+                                        {% for referral in user.referrals %}
+
+                                            <li class="align-items-center hidden-referrals">
+                                                <a
+                                                    title="{{ referral.referral_name ~ ' ' ~ referral.referral_surname}}"
+                                                    href="{{ path('entity.user.canonical', {'user' : referral.referral_id}) }}"
+                                                    class="rounded-circle overflow-hidden d-inline-block m-1 politician-modal"
+                                                >
+                                                    <img
+                                                        src="{{ referral.referral_img ? image_style_url(referral.referral_img, 'avatar_xs') : theme_path() ~ '/images/avatar.png' }}"
+                                                        class="rounded"
+                                                        width="34"
+                                                        alt="..."
+                                                    />
+                                                </a>
+                                            </li>
+                                        {% endfor %}
+                                        <!-- only for mobile version -->
+                                        {% if user.referral_count >=1 %}
+                                            <li class="referral-count" >
+                                                <a
+                                                    href="{{ path('entity.user.canonical', {'user' : user.uid, 'show_referral_modal' : 'true'}) }}"
+                                                    class="btn btn-light btn-sm m-1 px-2 bg-hover-success text-hover-white politician-modal"
+                                                >
+                                                    {{ user.referral_count }} +
+                                                </a>
+                                            </li>
                                         {% endif %}
                                     </ul>
                                 {% else %}

--- a/web/modules/custom/girchi_users/src/Commands/GirchiUsersCommands.php
+++ b/web/modules/custom/girchi_users/src/Commands/GirchiUsersCommands.php
@@ -209,4 +209,39 @@ class GirchiUsersCommands extends DrushCommands {
     }
   }
 
+  /**
+   * Set referral count command.
+   *
+   * @command girchi_users:del-ref-benefits
+   * @aliases del-ref-benefits
+   */
+  public  function deleteReferralBenefits() {
+    try {
+      // Delete referral benefits from user field.
+      $user_storage = $this->entityTypeManager->getStorage('user');
+      $uids = $user_storage->getQuery()
+        ->condition('field_referral_benefits', '0', '>')
+        ->execute();
+      $users = $user_storage->loadMultiple($uids);
+      foreach ($users as $user) {
+        $user->set('field_referral_benefits', '0');
+        $user->save();
+      }
+
+      // Delete referral benefits from db.
+      $referral_benefits_storage = $this->entityTypeManager->getStorage('node');
+      $referral_benefit_ids = $referral_benefits_storage->getQuery()
+        ->condition('type', 'referral_transaction')
+        ->execute();
+      $referral_benefits = $referral_benefits_storage->loadMultiple($referral_benefit_ids);
+
+      foreach ($referral_benefits as $referral_benefit) {
+        $referral_benefit->delete();
+      }
+    }
+    catch (\Exception $e) {
+      $this->loggerFactory->get('girchi_users')->error($e->getMessage());
+    }
+  }
+
 }

--- a/web/themes/custom/girchi/templates/forms/form--user-form.html.twig
+++ b/web/themes/custom/girchi/templates/forms/form--user-form.html.twig
@@ -74,6 +74,7 @@
                                 title="ქალაქი"
                                 class="selectpicker form-control form-control-lg pr-0"
                                 data-style="btn-lg btn-block"
+                                data-size = "10"
                             >
                                 {% for key, region in regions %}
                                     {% if region.children is not null %}


### PR DESCRIPTION
#724 #716 
## აღწერა
ტოპ რეფერალების ბლოკს დაემატა "მიმდინარე"(სულ) და ყველა რეფერალი.
"ტოპ რეფერალები" და  "ტოპ პარტნიორები" გადაკეთდა "რეფერალად" და "პარტნიორად".
წაიშალა ყველა რეფერალური ტრანზაქცია.
მომხმარებლის edit page-ზე რაიონები შემცირდა 10-მდე, მერე ისქროლება.

## ინსტალაცია
გატესტეთ ფროდაქშენის ბაზაზე, დაამატეთ ახალი დონაცია და შეამოწმეთ, რომ "მიმდინარეში" აისაბა.
`make drush cr`
`del-ref-benefits` ამ ბრძანების გაშვების შემდეგ დარწმუნდით რომ referral_transaction აღარ არსებობს.
