### PR TITLE
Limit loaded donations on homepage.

### DIFF
--- a/web/modules/custom/girchi_leaderboard/src/Plugin/Block/LeadPartner.php
+++ b/web/modules/custom/girchi_leaderboard/src/Plugin/Block/LeadPartner.php
@@ -97,17 +97,18 @@ class LeadPartner extends BlockBase implements ContainerFactoryPluginInterface {
     try {
       $user_storage = $this->entityTypeManager->getStorage('user');
       $donation_storage = $this->entityTypeManager->getStorage('donation');
+
       $donation_entity_ids_query = $donation_storage->getQuery()
         ->condition('status', 'OK')
         ->condition('user_id', '0', '!=')
         ->sort('amount', 'DESC');
+
       if ($mode === self::DONATION_DAILY) {
         $group = $donation_entity_ids_query
           ->andConditionGroup()
           ->condition('created', strtotime("now"), '<')
           ->condition('created', strtotime("-1 days"), '>');
         $donation_entity_ids_query->condition($group);
-        $donation_entity_ids = $donation_entity_ids_query->execute();
       }
       elseif ($mode === self::DONATION_WEEKLY) {
         $group = $donation_entity_ids_query
@@ -115,7 +116,6 @@ class LeadPartner extends BlockBase implements ContainerFactoryPluginInterface {
           ->condition('created', strtotime("now"), '<')
           ->condition('created', strtotime("-1 week"), '>');
         $donation_entity_ids_query->condition($group);
-        $donation_entity_ids = $donation_entity_ids_query->execute();
       }
       elseif ($mode === self::DONATION_MONTHLY) {
         $group = $donation_entity_ids_query
@@ -123,11 +123,11 @@ class LeadPartner extends BlockBase implements ContainerFactoryPluginInterface {
           ->condition('created', strtotime("now"), '<')
           ->condition('created', strtotime("-1 month"), '>');
         $donation_entity_ids_query->condition($group);
-        $donation_entity_ids = $donation_entity_ids_query->execute();
       }
-      else {
-        $donation_entity_ids = $donation_entity_ids_query->execute();
-      }
+
+      $donation_entity_ids_query->range(0, 5);
+      $donation_entity_ids = $donation_entity_ids_query->execute();
+
       $top_partners = $donation_storage->loadMultiple($donation_entity_ids);
       $final_partners = [];
       /** @var \Drupal\girchi_donations\Entity\Donation $top_partner */


### PR DESCRIPTION
@glontianano შევზღუდე დალოადებული ენთითიების (დონაციების) რაოდენობა, SQL LIMIT-ით (დრუპალში, entityfieldquery-ში range() მეთოდი), ისე, რომ პირველ გვერდზე ყველა დონაცია აღარ ლოადდება (რაც ძან მძიმეა).

ამის გამო, რა თქმა უდნა, "ყველა"-ზე დაჭერის მერე, პოპაპშიც აღარ გამოდის ყველა დონაცია.

გამოსავალი:
გავაკეთოთ ცალკე გვერდი დონაციების ისტორიისთვის (მაგალითად /donations), რომელზეც იქნება ჩვეულებრივი პეიჯერი და 50-50 დონაცია იქნება თითო გვერდზე. ამ ბლოკის "ყველა" ღილაკი კიდევ, პოპაპის მაგივრად წავიდეს იმ ახალ გვერდზე.

ეს PR დავმერჯოთ და გადავიტანოთ ხვალ და შემდეგ ამ ცალკე გვერდისთვის თასქი გავხსნათ და გავაკეთოტ.